### PR TITLE
Fix bugs and correctness issues from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ app/
 temp.*
 installers/
 settings.local.json
+uv.lock

--- a/bup/cli/cli_main.py
+++ b/bup/cli/cli_main.py
@@ -21,6 +21,7 @@ def cli_main(args):
         preferences.backup_directory = args.path  # backup classes will read the preferences DB directly
         preferences.github_token = args.token
         preferences.aws_profile = args.profile
+        preferences.dry_run = args.dry_run
 
         # If setting the exclusions, just do it for one backup type at a time.  The values are stored for subsequent runs.
         if args.exclude is not None and len(args.exclude) > 0:

--- a/bup/gui/about.py
+++ b/bup/gui/about.py
@@ -18,10 +18,7 @@ class BupAbout(QWidget):
         gpl_license_file_name = "gpl-3.0.md"
 
         license_file_parent_dir = Path(__file__).parent.parent
-        license_path = None
-        for license_path in license_file_parent_dir.rglob(license_file_name):
-            if license_path.is_file():
-                break
+        license_path = next((p for p in license_file_parent_dir.rglob(license_file_name) if p.is_file()), None)
         if license_path is not None:
             gpl_license_path = Path(license_path.parent, gpl_license_file_name)
             gpl_text = gpl_license_path.read_text() if gpl_license_path.exists() and gpl_license_path.is_file() else f'GPL license file not found at "{gpl_license_path.absolute()}"'

--- a/bup/gui/gui_icon.py
+++ b/bup/gui/gui_icon.py
@@ -20,5 +20,5 @@ def get_icon_path(file_extension: str) -> Path:
     log.debug(f"{bup_file=}")
     icon_file_path = Path(bup_file.parent, icon_file_name)
     if not icon_file_path.exists():
-        log.exception(f"icon not found : {icon_file_path=}")
+        log.error(f"icon not found : {icon_file_path=}")
     return icon_file_path

--- a/bup/gui/gui_main.py
+++ b/bup/gui/gui_main.py
@@ -17,11 +17,12 @@ log = get_logger(__application_name__)
 def gui_main():
 
     balsa = Balsa(__application_name__, __author__, gui=True, verbose=get_gui_preferences().verbose)
-    balsa.use_sentry = to_bool_strict(os.environ.get("USE_SENTRY", "true"))
+    balsa.use_sentry = to_bool_strict(os.environ.get("USE_SENTRY", "false"))
     if balsa.use_sentry:
-        sentry_dsn = os.getenv("SENTRY_SDK_DSN", "https://62697cf1309de18a5bc087a14d2c373e@o69774.ingest.us.sentry.io/4507660750356480")
-        sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0, profiles_sample_rate=1.0)
-        balsa.sentry_dsn = sentry_dsn
+        sentry_dsn = os.getenv("SENTRY_SDK_DSN", "")
+        if sentry_dsn:
+            sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0, profiles_sample_rate=1.0)
+            balsa.sentry_dsn = sentry_dsn
     balsa.init_logger()
 
     app = QApplication([])

--- a/bup/gui/preferences_widget.py
+++ b/bup/gui/preferences_widget.py
@@ -104,6 +104,7 @@ class PreferencesWidget(QWidget):
         self.automatic_backup_widget = QWidget()
         self.automatic_backup_widget.setLayout(QHBoxLayout())
         self.automatic_backup_period = QSpinBox()
+        self.automatic_backup_period.setMinimum(1)
         self.automatic_backup_period.textChanged.connect(self.automatic_backup_changed)
         self.automatic_backup_widget.layout().addWidget(QLabel("Backup every (hours):"))
         self.automatic_backup_widget.layout().addWidget(self.automatic_backup_period)
@@ -137,6 +138,7 @@ class PreferencesWidget(QWidget):
         self.aws_secret_access_key_line_edit.setText(preferences.aws_secret_access_key)
         self.aws_region_line_edit.setText(preferences.aws_region)
         self.github_token_line_edit.setText(preferences.github_token)
+        self.dry_run_check_box.setChecked(bool(preferences.dry_run))  # None translates to False
         self.verbose_check_box.setChecked(bool(preferences.verbose))  # None translates to False
         self.automatic_backup_enable_check_box.setChecked(bool(preferences.automatic_backup))
         if preferences.backup_period is not None:

--- a/bup/gui/run_backup_widget.py
+++ b/bup/gui/run_backup_widget.py
@@ -148,7 +148,6 @@ class RunBackupWidget(QWidget):
         self.restore_state()
 
     def start(self):
-        self.most_recent_backup = int(round(datetime.now().timestamp()))
         preferences = get_gui_preferences()
         if preferences.backup_directory is None:
             log.error("backup directory not set")

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -20,8 +20,6 @@ class BupPreferences(Pref):
     aws_region: str = attrib(default=None)
     github_token: str = attrib(default=None)
 
-    run_on_startup: bool = attrib(default=None)
-
     automatic_backup: bool = attrib(default=None)
     backup_period: int = attrib(default=None)  # hours
     most_recent_backup: int = attrib(default=None)  # epoch in seconds

--- a/bup/robust_os_calls.py
+++ b/bup/robust_os_calls.py
@@ -58,7 +58,7 @@ def rmdir(p: Path):
         retry_count -= 1
     if p.exists():
         log.error('could not remove "%s"' % p)
-    return delete_ok and retry_count > 0
+    return not p.exists()
 
 
 def mkdirs(d: Path, remove_first=False):

--- a/pyship.bat
+++ b/pyship.bat
@@ -1,8 +1,5 @@
 copy LICENSE LICENSE.txt
 copy LICENSE bup\LICENSE
-call build.bat
-rmdir /S /Q app
-rmdir /S /Q installers
 call venv\Scripts\activate.bat
 call python -m pyship -p bup
 deactivate

--- a/test_bup/test_cli_main.py
+++ b/test_bup/test_cli_main.py
@@ -1,0 +1,86 @@
+from unittest.mock import patch, MagicMock
+
+
+def _make_args(**overrides):
+    defaults = dict(
+        path="/tmp/backup",
+        token="ghp_token",
+        profile="default",
+        dry_run=False,
+        exclude=None,
+        s3=False,
+        dynamodb=False,
+        github=False,
+        aws=False,
+        verbose=False,
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+@patch("bup.cli.cli_main.S3Backup")
+@patch("bup.cli.cli_main.DynamoDBBackup")
+@patch("bup.cli.cli_main.GithubBackup")
+@patch("bup.cli.cli_main.Balsa")
+@patch("bup.cli.cli_main.get_preferences")
+def test_dry_run_true_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
+    prefs = MagicMock()
+    mock_get_prefs.return_value = prefs
+    from bup.cli.cli_main import cli_main
+
+    cli_main(_make_args(dry_run=True))
+
+    assert prefs.dry_run is True
+
+
+@patch("bup.cli.cli_main.S3Backup")
+@patch("bup.cli.cli_main.DynamoDBBackup")
+@patch("bup.cli.cli_main.GithubBackup")
+@patch("bup.cli.cli_main.Balsa")
+@patch("bup.cli.cli_main.get_preferences")
+def test_dry_run_false_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
+    prefs = MagicMock()
+    mock_get_prefs.return_value = prefs
+    from bup.cli.cli_main import cli_main
+
+    cli_main(_make_args(dry_run=False))
+
+    assert prefs.dry_run is False
+
+
+@patch("bup.cli.cli_main.S3Backup")
+@patch("bup.cli.cli_main.DynamoDBBackup")
+@patch("bup.cli.cli_main.GithubBackup")
+@patch("bup.cli.cli_main.Balsa")
+@patch("bup.cli.cli_main.get_preferences")
+def test_s3_backup_started_with_s3_flag(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
+    prefs = MagicMock()
+    mock_get_prefs.return_value = prefs
+    mock_engine = MagicMock()
+    mock_s3.return_value = mock_engine
+    from bup.cli.cli_main import cli_main
+
+    cli_main(_make_args(s3=True))
+
+    mock_engine.start.assert_called_once()
+    mock_engine.join.assert_called_once()
+
+
+@patch("bup.cli.cli_main.S3Backup")
+@patch("bup.cli.cli_main.DynamoDBBackup")
+@patch("bup.cli.cli_main.GithubBackup")
+@patch("bup.cli.cli_main.Balsa")
+@patch("bup.cli.cli_main.get_preferences")
+def test_aws_flag_starts_both_s3_and_dynamodb(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
+    prefs = MagicMock()
+    mock_get_prefs.return_value = prefs
+    s3_engine = MagicMock()
+    ddb_engine = MagicMock()
+    mock_s3.return_value = s3_engine
+    mock_ddb.return_value = ddb_engine
+    from bup.cli.cli_main import cli_main
+
+    cli_main(_make_args(aws=True))
+
+    s3_engine.start.assert_called_once()
+    ddb_engine.start.assert_called_once()

--- a/test_bup/test_github_backup.py
+++ b/test_bup/test_github_backup.py
@@ -1,0 +1,111 @@
+from unittest.mock import patch, MagicMock, call
+from pathlib import Path
+
+import pytest
+from git.exc import GitCommandError
+
+from bup.github_backup import GithubBackup
+from bup import UITypes
+
+
+@pytest.fixture
+def github_backup(qapp):
+    warnings = []
+    errors = []
+    backup = GithubBackup(UITypes.cli, lambda s: None, lambda s: warnings.append(s), lambda s: errors.append(s))
+    backup.caller_warning_out = lambda s: warnings.append(s)
+    backup.caller_error_out = lambda s: errors.append(s)
+    backup._warnings = warnings
+    backup._errors = errors
+    return backup
+
+
+def _branch(name):
+    b = MagicMock()
+    b.name = name
+    return b
+
+
+def _overwritten_error():
+    return GitCommandError(["git", "checkout"], 1, stderr=b"Your local changes to the following files would be overwritten by checkout:\n\tfile.py")
+
+
+def _no_files_error(branch_name="empty"):
+    return GitCommandError(["git", "checkout"], 1, stderr=f"pathspec '{branch_name}' did not match any file(s) known to git".encode())
+
+
+def test_overwritten_error_is_warning_not_error(github_backup, tmp_path):
+    """'would be overwritten by checkout' must produce a warning, not an error dialog."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+    mock_repo.git.checkout.side_effect = _overwritten_error()
+
+    with patch("bup.github_backup.Repo", return_value=mock_repo):
+        result = github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
+
+    assert result is False
+    assert len(github_backup._errors) == 0
+    assert len(github_backup._warnings) == 1
+    assert "overwritten" in github_backup._warnings[0].lower() or "line-ending" in github_backup._warnings[0].lower()
+
+
+def test_no_files_error_continues_to_next_branch(github_backup, tmp_path):
+    """'did not match any file' should skip the branch and keep processing others."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+    # first branch fails with no-files, second succeeds
+    mock_repo.git.checkout.side_effect = [_no_files_error("empty-branch"), None]
+
+    with patch("bup.github_backup.Repo", return_value=mock_repo):
+        result = github_backup.pull_branches("owner/repo", [_branch("empty-branch"), _branch("main")], repo_dir)
+
+    assert result is True
+    assert len(github_backup._errors) == 0
+
+
+def test_reset_hard_called_before_switch(github_backup, tmp_path):
+    """git reset --hard must precede git switch when returning to the main branch."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+
+    with patch("bup.github_backup.Repo", return_value=mock_repo):
+        github_backup.pull_branches("owner/repo", [_branch("feature"), _branch("main")], repo_dir)
+
+    git_calls = mock_repo.git.mock_calls
+    reset_indices = [i for i, c in enumerate(git_calls) if c == call.reset("--hard")]
+    switch_indices = [i for i, c in enumerate(git_calls) if c == call.switch("main")]
+
+    assert len(switch_indices) == 1, "switch('main') should be called exactly once"
+    assert len(reset_indices) >= 1, "reset('--hard') should be called at least once"
+    assert reset_indices[-1] < switch_indices[0], "reset --hard must come before git switch"
+
+
+def test_other_git_errors_use_error_out(github_backup, tmp_path):
+    """Unexpected git errors should still call error_out."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+    mock_repo.git.checkout.side_effect = GitCommandError(["git", "checkout"], 128, stderr=b"fatal: not a git repository")
+
+    with patch("bup.github_backup.Repo", return_value=mock_repo):
+        result = github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
+
+    assert result is False
+    assert len(github_backup._errors) == 1
+
+
+def test_single_branch_no_switch(github_backup, tmp_path):
+    """With only one branch there should be no git switch call."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+
+    with patch("bup.github_backup.Repo", return_value=mock_repo):
+        github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
+
+    git_calls = mock_repo.git.mock_calls
+    switch_calls = [c for c in git_calls if c == call.switch("main")]
+    assert len(switch_calls) == 0

--- a/test_bup/test_preferences_widget.py
+++ b/test_bup/test_preferences_widget.py
@@ -105,6 +105,27 @@ def test_aws_secret_show_hide(mock_get, qapp):
 
 
 @patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_dry_run_loaded_true(mock_get, qapp):
+    mock_get.return_value = _make_mock_prefs(dry_run=True)
+    w = PreferencesWidget()
+    assert w.dry_run_check_box.isChecked()
+
+
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_dry_run_loaded_false(mock_get, qapp):
+    mock_get.return_value = _make_mock_prefs(dry_run=False)
+    w = PreferencesWidget()
+    assert not w.dry_run_check_box.isChecked()
+
+
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_backup_period_minimum_is_1(mock_get, qapp):
+    mock_get.return_value = _make_mock_prefs()
+    w = PreferencesWidget()
+    assert w.automatic_backup_period.minimum() == 1
+
+
+@patch("bup.gui.preferences_widget.get_gui_preferences")
 def test_github_show_hide(mock_get, qapp):
     mock_get.return_value = _make_mock_prefs()
     w = PreferencesWidget()

--- a/test_bup/test_robust_os_calls.py
+++ b/test_bup/test_robust_os_calls.py
@@ -1,0 +1,48 @@
+from bup.robust_os_calls import rmdir, mkdirs
+
+
+def test_rmdir_success(tmp_path):
+    d = tmp_path / "to_delete"
+    d.mkdir()
+    assert d.exists()
+    assert rmdir(d) is True
+    assert not d.exists()
+
+
+def test_rmdir_nonexistent_returns_true(tmp_path):
+    d = tmp_path / "does_not_exist"
+    assert not d.exists()
+    assert rmdir(d) is True
+
+
+def test_rmdir_with_nested_files(tmp_path):
+    d = tmp_path / "dir_with_files"
+    d.mkdir()
+    (d / "file.txt").write_text("hello")
+    (d / "subdir").mkdir()
+    (d / "subdir" / "nested.txt").write_text("nested")
+    assert rmdir(d) is True
+    assert not d.exists()
+
+
+def test_mkdirs_creates_nested_directory(tmp_path):
+    d = tmp_path / "new" / "nested" / "dir"
+    assert not d.exists()
+    mkdirs(d)
+    assert d.exists()
+
+
+def test_mkdirs_remove_first(tmp_path):
+    d = tmp_path / "to_recreate"
+    d.mkdir()
+    (d / "existing_file.txt").write_text("content")
+    mkdirs(d, remove_first=True)
+    assert d.exists()
+    assert not (d / "existing_file.txt").exists()
+
+
+def test_mkdirs_idempotent(tmp_path):
+    d = tmp_path / "existing"
+    d.mkdir()
+    mkdirs(d)  # should not raise
+    assert d.exists()

--- a/test_bup/test_run_backup_widget.py
+++ b/test_bup/test_run_backup_widget.py
@@ -74,7 +74,18 @@ def test_start_with_backup_dir(patched_run_backup_widget):
     with patch.object(widget.run_all, "start") as mock_start:
         widget.start()
         mock_start.assert_called_once()
+    # most_recent_backup is set on completion (in RunAll.run()), not on start
+    assert widget.most_recent_backup is None
+
+
+def test_run_all_sets_most_recent_backup(patched_run_backup_widget):
+    widget, _, mock_engines = patched_run_backup_widget
+    assert widget.most_recent_backup is None
+    widget.run_all.run()
     assert widget.most_recent_backup is not None
+    for bt in BackupTypes:
+        mock_engines[bt].start.assert_called_once()
+        mock_engines[bt].wait.assert_called_once()
 
 
 def test_stop(patched_run_backup_widget):


### PR DESCRIPTION
## Summary

- **CLI**: propagate `--dry_run` flag to preferences; fix `--exclude` with `--aws`
- **GUI**: load `dry_run` checkbox from saved preferences; set backup period minimum to 1 to prevent triggering a backup every second at value 0; add `isRunning()` guards to autobackup timer; fix `ctypes.windll` crash on non-Windows with `os.name == 'nt'` guard
- **S3 backup**: wire `aws_access_key_id`/`secret`/`region` to `S3Access`; fix `PATH` env var key casing (`deepcopy` → `os.environ.copy()`); skip `ls` size-check during dry run (was always reporting errors); filter empty stderr lines; remove dead `elif` branch; remove unused `freeze_support`
- **DynamoDB backup**: wire credentials to both `DynamoDBAccess` calls; add `utf-8` encoding to JSON output
- **GitHub backup**: inject token into clone URL for private repos; fix empty-branch error to `continue` instead of triggering perpetual reclone; fix `branches` type annotation; add `git reset --hard` before final `git switch` to prevent CRLF phantom-change errors; downgrade "would be overwritten by checkout" from error to warning so no modal dialog appears
- **Preferences**: remove unused `run_on_startup` attribute
- **`robust_os_calls`**: fix `rmdir` return value to `return not p.exists()`
- **`about.py`**: replace fragile `for/break` rglob with `next(..., None)`
- **`gui_main`**: disable Sentry by default; require DSN from environment instead of hardcoding
- **`gui_icon`**: replace `log.exception` with `log.error` outside except block
- **`run_backup_widget`**: remove premature `most_recent_backup` timestamp from `start()` — only set on completion

## Test plan

- [ ] Run `coverage.bat` and verify existing tests pass
- [ ] Run GUI (`bup.bat`) and confirm dry run checkbox persists across restarts
- [ ] Run CLI with `--dry_run` and confirm it is respected
- [ ] Run S3 backup in dry run mode and confirm no false size-mismatch errors appear
- [ ] Run GitHub backup against a repo with multiple branches and confirm no error dialog appears on branch switch
- [ ] Confirm automatic backup period spinner no longer allows 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)