### PR TITLE
Guard against missing git executable at startup

### DIFF
--- a/bup/github_backup.py
+++ b/bup/github_backup.py
@@ -1,9 +1,8 @@
 from pathlib import Path
+import shutil
 import time
 
 import github3
-from git import Repo
-from git.exc import GitCommandError, InvalidGitRepositoryError
 from github3.exceptions import AuthenticationFailed
 from balsa import get_logger
 from typeguard import typechecked
@@ -18,6 +17,12 @@ class GithubBackup(BupBase):
     backup_type = BackupTypes.github
 
     def run(self):
+        if shutil.which("git") is None:
+            self.error_out("git executable not found in PATH - GitHub backup cannot run")
+            return
+
+        from git import Repo
+        from git.exc import GitCommandError
 
         preferences = get_preferences(self.ui_type)
         dry_run = preferences.dry_run
@@ -88,6 +93,8 @@ class GithubBackup(BupBase):
 
     @typechecked()
     def pull_branches(self, repo_name: str, branches: list, repo_dir: Path) -> bool:
+        from git import Repo
+        from git.exc import GitCommandError, InvalidGitRepositoryError
 
         try:
             git_repo = Repo(repo_dir)

--- a/test_bup/test_github_backup.py
+++ b/test_bup/test_github_backup.py
@@ -41,7 +41,7 @@ def test_overwritten_error_is_warning_not_error(github_backup, tmp_path):
     mock_repo = MagicMock()
     mock_repo.git.checkout.side_effect = _overwritten_error()
 
-    with patch("bup.github_backup.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         result = github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
 
     assert result is False
@@ -58,7 +58,7 @@ def test_no_files_error_continues_to_next_branch(github_backup, tmp_path):
     # first branch fails with no-files, second succeeds
     mock_repo.git.checkout.side_effect = [_no_files_error("empty-branch"), None]
 
-    with patch("bup.github_backup.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         result = github_backup.pull_branches("owner/repo", [_branch("empty-branch"), _branch("main")], repo_dir)
 
     assert result is True
@@ -71,7 +71,7 @@ def test_reset_hard_called_before_switch(github_backup, tmp_path):
     repo_dir.mkdir()
     mock_repo = MagicMock()
 
-    with patch("bup.github_backup.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         github_backup.pull_branches("owner/repo", [_branch("feature"), _branch("main")], repo_dir)
 
     git_calls = mock_repo.git.mock_calls
@@ -90,7 +90,7 @@ def test_other_git_errors_use_error_out(github_backup, tmp_path):
     mock_repo = MagicMock()
     mock_repo.git.checkout.side_effect = GitCommandError(["git", "checkout"], 128, stderr=b"fatal: not a git repository")
 
-    with patch("bup.github_backup.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         result = github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
 
     assert result is False
@@ -103,7 +103,7 @@ def test_single_branch_no_switch(github_backup, tmp_path):
     repo_dir.mkdir()
     mock_repo = MagicMock()
 
-    with patch("bup.github_backup.Repo", return_value=mock_repo):
+    with patch("git.Repo", return_value=mock_repo):
         github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
 
     git_calls = mock_repo.git.mock_calls


### PR DESCRIPTION
## Summary

- Defer `from git import Repo` imports from module level into `run()` and `pull_branches()` so a missing `git` executable no longer crashes the app at startup
- Add an explicit `shutil.which("git")` check at the top of `run()` that reports an error to the UI and returns early if `git` is not found in PATH
- Update test patch targets from `bup.github_backup.Repo` to `git.Repo` to match the new lazy-import approach

## Test plan

- [x] All 56 tests pass
- [x] App starts normally on machines without `git` in PATH
- [x] GitHub backup reports a clear error message if `git` is missing, instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)