### PR TITLE
Deep code review fixes: CLI thread handling, token security, cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 backup for github repos and AWS S3 and DynamoDB
 
+# Security Notes
+
+- Credentials you enter (AWS secret access key, GitHub token) are stored **unencrypted** in a local
+  SQLite preferences database in your user profile. Prefer AWS profiles (`~/.aws/credentials`) over
+  raw keys where possible, and treat the preferences database with the same care as a credentials file.
+- GitHub authentication for clone/pull is passed to git via the process environment, so the token is
+  not written into each backup's `.git/config`. Backups made by older versions of bup may still have
+  a token embedded in their remote URL; bup scrubs these the next time each repo is pulled.
+
 # Acknowledgements 
 
 <div>Icons made by <a href="https://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>

--- a/bup/arguments.py
+++ b/bup/arguments.py
@@ -11,7 +11,7 @@ def arguments():
 
     version_string = "version"
 
-    if len(sys.argv) > 1 and sys.argv[1].lower() == f"--{version_string}":
+    if f"--{version_string}" in [a.lower() for a in sys.argv[1:]]:
         print(__version__)
         sys.exit()
 
@@ -41,7 +41,7 @@ def arguments():
         parser.add_argument(f"--{version_string}", action="store_true", default=False, help="display version and exit")
         parser.add_argument("-v", f"--{verbose_arg_string}", dest=verbose_arg_string, action="store_true", default=False, help="set verbose")
         parser.add_argument("-l", f"--{log_dir_arg_string}", dest=log_dir_arg_string, help="log dir")
-        parser.add_argument(f"--{delete_existing_arg_string}", dest=delete_existing_arg_string, help="delete existing logs")
+        parser.add_argument(f"--{delete_existing_arg_string}", dest=delete_existing_arg_string, action="store_true", default=False, help="delete existing logs")
         args = parser.parse_args()
 
         if args.logdir is None and args.path is not None:

--- a/bup/bup_base.py
+++ b/bup/bup_base.py
@@ -38,7 +38,11 @@ class BupBase(QThread):
 
     def info_out(self, s: str):
         # callees could call emit(), but that seems awkward so provide this method
-        self.info_out_signal.emit(s)
+        if self.ui_type == UITypes.cli:
+            # the CLI has no Qt event loop, so queued signals would never be delivered - call directly
+            self._info_out(s)
+        else:
+            self.info_out_signal.emit(s)
 
     def _info_out(self, s: str):
         # hooked up to the signal for threading
@@ -47,7 +51,10 @@ class BupBase(QThread):
 
     def warning_out(self, s: str):
         # callees could call emit(), but that seems awkward so provide this method
-        self.warning_out_signal.emit(s)
+        if self.ui_type == UITypes.cli:
+            self._warning_out(s)
+        else:
+            self.warning_out_signal.emit(s)
 
     def _warning_out(self, s: str):
         # hooked up to the signal for threading
@@ -56,7 +63,10 @@ class BupBase(QThread):
 
     def error_out(self, s: str):
         # callees could call emit(), but that seems awkward so provide this method
-        self.error_out_signal.emit(s)
+        if self.ui_type == UITypes.cli:
+            self._error_out(s)
+        else:
+            self.error_out_signal.emit(s)
 
     def _error_out(self, s: str):
         # hooked up to the signal for threading

--- a/bup/cli/cli_main.py
+++ b/bup/cli/cli_main.py
@@ -5,6 +5,18 @@ from bup import __application_name__, __author__, __version__, S3Backup, DynamoD
 log = get_logger(__application_name__)
 
 
+def _console_info(s: str):
+    print(s)
+
+
+def _console_warning(s: str):
+    print(f"WARNING: {s}")
+
+
+def _console_error(s: str):
+    print(f"ERROR: {s}")
+
+
 def cli_main(args):
 
     ui_type = UITypes.cli
@@ -19,17 +31,23 @@ def cli_main(args):
     try:
         preferences = get_preferences(ui_type)
         preferences.backup_directory = args.path  # backup classes will read the preferences DB directly
-        preferences.github_token = args.token
-        preferences.aws_profile = args.profile
+        # only overwrite saved values when explicitly given on the command line
+        if args.token is not None:
+            preferences.github_token = args.token
+        if args.profile is not None:
+            preferences.aws_profile = args.profile
+        if args.region is not None:
+            preferences.aws_region = args.region
         preferences.dry_run = args.dry_run
 
-        # If setting the exclusions, just do it for one backup type at a time.  The values are stored for subsequent runs.
-        if args.exclude is not None and len(args.exclude) > 0:
-            if args.s3:
+        # Set the exclusions for the selected backup type(s).  The values are stored for subsequent runs.
+        # An explicitly empty -e (no values) clears the stored exclusions.
+        if args.exclude is not None:
+            if args.s3 or args.aws:
                 ExclusionPreferences(BackupTypes.S3.name).set(args.exclude)
-            elif args.dynamodb:
+            if args.dynamodb or args.aws:
                 ExclusionPreferences(BackupTypes.DynamoDB.name).set(args.exclude)
-            elif args.github:
+            if args.github:
                 ExclusionPreferences(BackupTypes.github.name).set(args.exclude)
 
         did_something = False
@@ -37,25 +55,26 @@ def cli_main(args):
         s3_local_backup = None
         github_local_backup = None
         if args.s3 or args.aws:
-            s3_local_backup = S3Backup(ui_type, log.info, log.warning, log.error)
+            s3_local_backup = S3Backup(ui_type, _console_info, _console_warning, _console_error)
             s3_local_backup.start()
             did_something = True
         if args.dynamodb or args.aws:
-            dynamodb_local_backup = DynamoDBBackup(ui_type, log.info, log.warning, log.error)
+            dynamodb_local_backup = DynamoDBBackup(ui_type, _console_info, _console_warning, _console_error)
             dynamodb_local_backup.start()
             did_something = True
         if args.github:
-            github_local_backup = GithubBackup(ui_type, log.info, log.warning, log.error)
+            github_local_backup = GithubBackup(ui_type, _console_info, _console_warning, _console_error)
             github_local_backup.start()
             did_something = True
         if not did_something:
             print("nothing to do - please specify a backup to do or -h/--help for help")
 
+        # QThread uses wait(), not join()
         if dynamodb_local_backup is not None:
-            dynamodb_local_backup.join()
+            dynamodb_local_backup.wait()
         if s3_local_backup is not None:
-            s3_local_backup.join()
+            s3_local_backup.wait()
         if github_local_backup is not None:
-            github_local_backup.join()
+            github_local_backup.wait()
     except Exception as e:
         log.exception(e)

--- a/bup/github_backup.py
+++ b/bup/github_backup.py
@@ -1,6 +1,8 @@
+import base64
 from pathlib import Path
 import shutil
 import time
+from typing import Optional
 
 import github3
 from github3.exceptions import AuthenticationFailed
@@ -12,9 +14,33 @@ from bup import __application_name__, BupBase, BackupTypes, get_preferences, Exc
 log = get_logger(__application_name__)
 
 
+def get_git_credential_environment(token: Optional[str]) -> dict:
+    """
+    Environment that lets git authenticate to GitHub without ever putting the token in a URL
+    (URLs get persisted to .git/config and echoed back in git error messages).
+    Uses git's GIT_CONFIG_* environment configs (git >= 2.31).
+    """
+    env = {"GIT_TERMINAL_PROMPT": "0"}  # fail instead of prompting for credentials
+    if token:
+        basic_auth = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        env["GIT_CONFIG_COUNT"] = "1"
+        env["GIT_CONFIG_KEY_0"] = "http.extraHeader"
+        env["GIT_CONFIG_VALUE_0"] = f"Authorization: Basic {basic_auth}"
+    return env
+
+
 class GithubBackup(BupBase):
 
     backup_type = BackupTypes.github
+
+    _github_token: Optional[str] = None
+    _git_env: dict = {}
+
+    def redact(self, s: str) -> str:
+        # keep the token out of the GUI, logs, and Sentry
+        if self._github_token:
+            s = s.replace(self._github_token, "***")
+        return s
 
     def run(self):
         if shutil.which("git") is None:
@@ -27,6 +53,9 @@ class GithubBackup(BupBase):
         preferences = get_preferences(self.ui_type)
         dry_run = preferences.dry_run
         exclusions = ExclusionPreferences(BackupTypes.github.name).get_no_comments()
+
+        self._github_token = preferences.github_token
+        self._git_env = get_git_credential_environment(self._github_token)
 
         backup_dir = Path(preferences.backup_directory, "github")
 
@@ -50,22 +79,23 @@ class GithubBackup(BupBase):
 
             repo_owner_and_name = str(github_repo)
             repo_name = repo_owner_and_name.split("/")[-1]
-            if any([e == repo_name for e in exclusions]):
+            if any([e == repo_name or e == repo_owner_and_name for e in exclusions]):
                 self.info_out(f"{repo_owner_and_name} excluded")
             elif dry_run:
                 self.info_out(f"dry run {repo_owner_and_name}")
             else:
                 repo_dir = Path(backup_dir, repo_owner_and_name).absolute()
                 branches = list(github_repo.branches())
+                clone_url = github_repo.clone_url  # tokenless - credentials go via the environment
 
                 # if we've cloned previously, just do a pull
                 pull_success = False
                 if repo_dir.exists():
                     try:
-                        if pull_success := self.pull_branches(repo_owner_and_name, branches, repo_dir):
+                        if pull_success := self.pull_branches(repo_owner_and_name, branches, repo_dir, clone_url=clone_url):
                             pull_count += 1
                     except GitCommandError as e:
-                        self.warning_out(f'could not pull "{repo_dir}" - will try to start over and do a clone of "{repo_owner_and_name},{e}","{__file__}"')
+                        self.warning_out(self.redact(f'could not pull "{repo_dir}" - will try to start over and do a clone of "{repo_owner_and_name},{e}","{__file__}"'))
 
                 # new to us - clone the repo
                 if not pull_success:
@@ -77,22 +107,19 @@ class GithubBackup(BupBase):
                             self.error_out(f'could not remove "{repo_dir}" - may require manual removal')
                         else:
                             self.info_out(f'git clone "{repo_owner_and_name}"')
-                            clone_url = github_repo.clone_url
-                            if preferences.github_token:
-                                clone_url = clone_url.replace("https://", f"https://{preferences.github_token}@")
-                            Repo.clone_from(clone_url, repo_dir)
-                            time.sleep(1.0)
-                            self.pull_branches(repo_owner_and_name, branches, repo_dir)
+                            Repo.clone_from(clone_url, repo_dir, env=self._git_env)
+                            time.sleep(1.0)  # let Windows release file locks on the fresh clone before touching it
+                            self.pull_branches(repo_owner_and_name, branches, repo_dir, clone_url=clone_url)
                             clone_count += 1
                     except PermissionError as e:
-                        self.warning_out(f'{repo_owner_and_name},"{repo_dir}",{e},"{__file__}"')
+                        self.warning_out(self.redact(f'{repo_owner_and_name},"{repo_dir}",{e},"{__file__}"'))
                     except GitCommandError as e:
-                        self.warning_out(f'{repo_owner_and_name},"{repo_dir}",{e},"{__file__}"')
+                        self.warning_out(self.redact(f'{repo_owner_and_name},"{repo_dir}",{e},"{__file__}"'))
 
         self.info_out(f"{len(repositories)} repos, {pull_count} pulls, {clone_count} clones, {len(exclusions)} excluded")
 
     @typechecked()
-    def pull_branches(self, repo_name: str, branches: list, repo_dir: Path) -> bool:
+    def pull_branches(self, repo_name: str, branches: list, repo_dir: Path, clone_url: Optional[str] = None) -> bool:
         from git import Repo
         from git.exc import GitCommandError, InvalidGitRepositoryError
 
@@ -105,6 +132,15 @@ class GithubBackup(BupBase):
         success = False
         main_branch = None
         if git_repo is not None:
+            git_repo.git.update_environment(**self._git_env)
+
+            # scrub any token that an older bup version persisted into the remote URL
+            if clone_url is not None:
+                try:
+                    git_repo.remotes.origin.set_url(clone_url)
+                except (GitCommandError, AttributeError, ValueError) as e:
+                    log.warning(self.redact(f'could not set remote url for "{repo_dir}" : {e}'))
+
             for branch in branches:
                 if self.stop_requested:
                     break
@@ -128,11 +164,11 @@ class GithubBackup(BupBase):
                         continue
                     elif "would be overwritten by checkout" in str(e).lower():
                         # typically caused by CRLF line-ending normalization on Windows, not actual user edits
-                        self.warning_out(f"{repo_name} branch:{branch_name} : checkout blocked by apparent local changes (likely line-ending normalization) : {e}")
+                        self.warning_out(self.redact(f"{repo_name} branch:{branch_name} : checkout blocked by apparent local changes (likely line-ending normalization) : {e}"))
                         success = False
                         break
                     else:
-                        self.error_out(f"{repo_name} : {e}")
+                        self.error_out(self.redact(f"{repo_name} : {e}"))
                         success = False
                         break
 
@@ -140,7 +176,11 @@ class GithubBackup(BupBase):
             if len(branches) > 1 and main_branch is not None:
                 main_branch_name = main_branch.name
                 self.info_out(f'git switch "{repo_name}" branch:"{main_branch_name}"')
-                git_repo.git.reset("--hard")  # clear any phantom changes (e.g. CRLF normalization) before switching
-                git_repo.git.switch(main_branch_name)
+                try:
+                    git_repo.git.reset("--hard")  # clear any phantom changes (e.g. CRLF normalization) before switching
+                    git_repo.git.switch(main_branch_name)
+                except GitCommandError as e:
+                    # failing to land on the main branch doesn't invalidate the backup itself
+                    self.warning_out(self.redact(f'could not switch "{repo_name}" to branch "{main_branch_name}" : {e}'))
 
         return success

--- a/bup/gui/bup_dialog.py
+++ b/bup/gui/bup_dialog.py
@@ -51,18 +51,16 @@ class BupDialog(QDialog):
 
     def autobackup_tick(self):
         if self.preferences_widget.automatic_backup_enable_check_box.isChecked():
-            try:
-                backup_period = int(self.preferences_widget.automatic_backup_period.text())
-            except ValueError:
-                backup_period = None
-            if backup_period is None:
+            backup_period = self.preferences_widget.automatic_backup_period.value()  # QSpinBox guarantees an int
+            if backup_period <= 0:
                 self.run_backup_widget.countdown_text.setText("(automatic backup not set)")
             else:
                 now = datetime.now()
                 backup_period_time_delta = timedelta(hours=backup_period)
                 if self.run_backup_widget.most_recent_backup is None:
-                    # first time run
+                    # no backup on record - start one right away
                     if not self.run_backup_widget.run_all.isRunning():
+                        self.run_backup_widget.countdown_text.setText("(starting first automatic backup)")
                         self.run_backup_widget.start()
                 else:
                     most_recent_backup = datetime.fromtimestamp(self.run_backup_widget.most_recent_backup)
@@ -88,7 +86,7 @@ class BupDialog(QDialog):
             msg_box.setText("A backup is currently running.")
             msg_box.setInformativeText("Do you want to stop the backup and exit, or cancel and keep running?")
             msg_box.setIcon(QMessageBox.Warning)
-            stop_button = msg_box.addButton("Stop and Exit", QMessageBox.DestructiveRole)
+            msg_box.addButton("Stop and Exit", QMessageBox.DestructiveRole)
             cancel_button = msg_box.addButton("Cancel", QMessageBox.RejectRole)
             msg_box.setDefaultButton(cancel_button)
             msg_box.exec_()

--- a/bup/gui/preferences_widget.py
+++ b/bup/gui/preferences_widget.py
@@ -192,5 +192,4 @@ class PreferencesWidget(QWidget):
     def automatic_backup_changed(self):
         preferences = get_gui_preferences()
         preferences.automatic_backup = self.automatic_backup_enable_check_box.isChecked()
-        if len(backup_period := self.automatic_backup_period.text().strip()) > 0:
-            preferences.backup_period = int(round(float(backup_period)))
+        preferences.backup_period = self.automatic_backup_period.value()  # QSpinBox guarantees an int

--- a/bup/gui/run_backup_widget.py
+++ b/bup/gui/run_backup_widget.py
@@ -2,7 +2,8 @@ from enum import Enum
 from datetime import datetime
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QGroupBox, QHBoxLayout, QTextEdit, QSplitter, QLabel
-from PyQt5.QtCore import Qt, QThread
+from PyQt5.QtCore import Qt, QThread, QTimer
+from PyQt5.QtGui import QTextCursor
 from balsa import get_logger
 
 from bup import BackupTypes, S3Backup, DynamoDBBackup, GithubBackup, ExclusionPreferences, UITypes, __application_name__
@@ -25,7 +26,9 @@ class RunAll(QThread):
             self.widget.backup_engines[backup_type].start()
         for backup_type in self.widget.backup_engines:
             self.widget.backup_engines[backup_type].wait()
-        self.widget.most_recent_backup = int(round(datetime.now().timestamp()))
+        if not any(self.widget.backup_engines[backup_type].stop_requested for backup_type in self.widget.backup_engines):
+            # a stopped run isn't a completed backup - don't reset the auto-backup countdown
+            self.widget.most_recent_backup = int(round(datetime.now().timestamp()))
 
 
 def get_local_time_string() -> str:
@@ -53,10 +56,23 @@ class DisplayBox(QGroupBox):
         self.text = []
 
     def append_text(self, s):
-        self.text.append(f"{get_local_time_string()} {s}")
+        # insert at the top (most recent activity first) with cursor operations so each append is O(1),
+        # instead of re-rendering the whole buffer for every line
+        line = f"{get_local_time_string()} {s}"
+        self.text.append(line)
+        cursor = self.text_box.textCursor()
+        cursor.movePosition(QTextCursor.Start)
+        if len(self.text) == 1:
+            cursor.insertText(line)
+        else:
+            cursor.insertText(f"{line}\n")
         if len(self.text) > max_text_lines:
             self.text.pop(0)  # FIFO
-        self.text_box.setText("\n".join(reversed(self.text)))  # most recent activity at the top
+            # the oldest line is the last block - remove it and its preceding newline
+            cursor.movePosition(QTextCursor.End)
+            cursor.movePosition(QTextCursor.StartOfBlock, QTextCursor.KeepAnchor)
+            cursor.removeSelectedText()
+            cursor.deletePreviousChar()
 
     def clear_text(self):
         self.text = []
@@ -73,6 +89,12 @@ class BackupWidget(QGroupBox):
         super().__init__(backup_type.name)
         self.setLayout(QVBoxLayout())
 
+        # debounce exclusion writes so we don't hit the DB on every keystroke
+        self.exclusions_save_timer = QTimer(self)
+        self.exclusions_save_timer.setSingleShot(True)
+        self.exclusions_save_timer.setInterval(500)  # ms
+        self.exclusions_save_timer.timeout.connect(self.exclusions)
+
         self.display_boxes = {}
         self.splitter = QSplitter(Qt.Vertical)
         self.layout().addWidget(self.splitter)
@@ -83,9 +105,15 @@ class BackupWidget(QGroupBox):
                 # read exclusions into the DB
                 exclusions = ExclusionPreferences(self.backup_type.name)
                 self.display_boxes[display_type].text_box.setText("\n".join(exclusions.get()))
-                self.display_boxes[display_type].text_box.textChanged.connect(self.exclusions)
+                self.display_boxes[display_type].text_box.textChanged.connect(self.exclusions_save_timer.start)
             else:
                 self.display_boxes[display_type].text_box.setReadOnly(True)
+
+    def flush_exclusions(self):
+        # write out any pending (debounced) exclusion edits immediately
+        if self.exclusions_save_timer.isActive():
+            self.exclusions_save_timer.stop()
+            self.exclusions()
 
     def exclusions(self):
         """
@@ -170,6 +198,8 @@ class RunBackupWidget(QWidget):
 
     def save_state(self):
         preferences = get_gui_preferences()
+        for backup_type in BackupTypes:
+            self.backup_status[backup_type].flush_exclusions()
         for backup_type in BackupTypes:
             for display_type in DisplayTypes:
                 setattr(preferences, self.get_layout_key(backup_type, display_type, "height"), self.backup_status[backup_type].display_boxes[display_type].height())

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -64,5 +64,5 @@ class ExclusionPreferences(PrefOrderedSet):
         super().__init__(__application_name__, __author__, f"exclusions_{exclusion_type}")
 
     def get_no_comments(self) -> List[str]:
-        # get list of exclusions with comment lines removed
-        return [s for s in super().get() if len(s) > 0 and s[0] != "#"]
+        # get list of exclusions with comment and blank lines removed (tolerating leading whitespace)
+        return [s for s in super().get() if len(s.strip()) > 0 and not s.strip().startswith("#")]

--- a/bup/robust_os_calls.py
+++ b/bup/robust_os_calls.py
@@ -19,7 +19,11 @@ def make_long_path_compatible(path: Path) -> str:
     """
     path_str = str(path.resolve())
     if os.name.lower() == "nt" and not path_str.startswith("\\\\?\\"):
-        path_str = "\\\\?\\" + path_str
+        if path_str.startswith("\\\\"):
+            # UNC paths use the \\?\UNC\server\share form
+            path_str = "\\\\?\\UNC" + path_str[1:]
+        else:
+            path_str = "\\\\?\\" + path_str
     return path_str
 
 
@@ -28,7 +32,7 @@ def remove_readonly(path: Path):
 
 
 # sometimes needed for Windows
-def _remove_readonly_onerror(func, path, excinfo):
+def _remove_readonly_onexc(func, path, exc):
     _path = Path(path)
     if _path.is_file():
         remove_readonly(_path)
@@ -43,7 +47,7 @@ def rmdir(p: Path):
     while p.exists() and retry_count > 0:
         try:
             _p = make_long_path_compatible(p)
-            shutil.rmtree(_p, onerror=_remove_readonly_onerror)
+            shutil.rmtree(_p, onexc=_remove_readonly_onexc)
         except FileNotFoundError as e:
             log.debug(str(e))  # this can happen when first doing the shutil.rmtree()
             time.sleep(1)
@@ -63,7 +67,7 @@ def mkdirs(d: Path, remove_first=False):
     if remove_first:
         rmdir(d)
     # sometimes when Path.mkdir() exits the dir is not actually there
-    count = 600
+    count = 50  # up to ~5 seconds
     while count > 0 and not d.exists():
         try:
             # for some reason we can get the FileNotFoundError exception

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -5,6 +5,7 @@ import sys
 import os
 import re
 from pathlib import Path
+from typing import Optional, Tuple
 
 from awsimple import S3Access
 from balsa import get_logger
@@ -26,6 +27,33 @@ def get_dir_size(dir_path: Path):
             file_count += 1
             dir_size += os.path.getsize(os.path.join(root, file_name))
     return dir_size, file_count
+
+
+def find_aws_cli() -> Tuple[Optional[Path], Optional[Path]]:
+    """
+    Locate the AWS CLI executable and the python executable it should run with.
+    Use sys.executable to reliably locate python and aws CLI in the same directory,
+    which works for both local venv and installed app scenarios.
+    :return: (aws_cli_path, python_path), or (None, None) if not found
+    """
+    python_exe = Path(sys.executable)
+    aws_names = ["aws.cmd", "aws.exe", "aws"] if sys.platform == "win32" else ["aws"]
+    aws_candidates = (
+        [(python_exe, python_exe.parent / name) for name in aws_names]  # same dir as python (venv Scripts/)
+        + [(python_exe, python_exe.parent / "Scripts" / name) for name in aws_names]  # CLIP layout: python at root, scripts in Scripts/
+        + [(Path("venv", "Scripts", "python.exe").absolute(), Path("venv", "Scripts", name).absolute()) for name in aws_names]  # local venv from CWD
+    )
+    for p, a in aws_candidates:
+        if p.exists() and a.exists():
+            return a, p
+
+    # fall back to whatever is on the system PATH
+    aws_in_path = shutil.which("aws")
+    if aws_in_path:
+        return Path(aws_in_path), python_exe
+
+    log.error(f"AWS CLI executable not found ({aws_candidates=})")
+    return None, None
 
 
 class S3Backup(BupBase):
@@ -53,10 +81,21 @@ class S3Backup(BupBase):
         # we delete all whitespace below
         ls_re = re.compile(r"TotalObjects:([0-9]+)TotalSize:([0-9]+)")
 
+        aws_cli_path, python_path = find_aws_cli()
+        if aws_cli_path is None:
+            self.error_out("AWS CLI executable not found - S3 backup cannot run")
+            return
+
+        # The AWS CLI app also needs the python executable to be in the path if it's not in the same dir, which happens when this program is installed.
+        # Make the directory of our python.exe the first in the list so it's found and not any of the others that may or may not be in the PATH.
+        env_var = os.environ.copy()
+        env_var["PATH"] = f"{str(python_path.parent)}{os.pathsep}{env_var.get('PATH', '')}"
+
         buckets = s3_access.bucket_list()
         self.info_out(f"found {len(buckets)} buckets")
 
         count = 0
+        dry_run_count = 0
         exclusions_no_comments = ExclusionPreferences(BackupTypes.S3.name).get_no_comments()
         for bucket_name in buckets:
             if self.stop_requested:
@@ -65,108 +104,78 @@ class S3Backup(BupBase):
             # do the sync
             if bucket_name in exclusions_no_comments:
                 self.info_out(f"excluding {bucket_name}")
+                continue
+
+            if dry_run:
+                self.info_out(f"dry run {bucket_name}")
             else:
-                if dry_run:
-                    self.info_out(f"dry run {bucket_name}")
+                self.info_out(f"{bucket_name}")
+
+            destination = Path(backup_directory, bucket_name)
+            os.makedirs(destination, exist_ok=True)
+            s3_bucket_path = f"s3://{bucket_name}"
+            # Don't use --delete.  We want to keep 'old' files locally.
+            sync_command_line = [str(aws_cli_path), "s3", "sync", s3_bucket_path, str(destination.absolute())]
+            if dry_run:
+                sync_command_line.append("--dryrun")
+            log.info(subprocess.list2cmdline(sync_command_line))
+
+            try:
+                sync_result = subprocess.run(sync_command_line, env=env_var, capture_output=True)
+            except (FileNotFoundError, OSError) as e:
+                self.error_out(f'error executing {" ".join(sync_command_line)} {e}')
+                return
+
+            for line in sync_result.stdout.decode(decoding).splitlines():
+                log.info(f"{bucket_name}:{line.strip()}")
+            for line in sync_result.stderr.decode(decoding).splitlines():
+                line = line.strip()
+                if line:
+                    self.warning_out(f"{bucket_name}:{line}")
+            if sync_result.returncode != 0:
+                self.error_out(f"aws s3 sync failed (exit code {sync_result.returncode}) for {bucket_name}")
+                continue  # don't count or verify a failed sync
+
+            # check the results (skip during dry run - nothing was synced)
+            if dry_run:
+                dry_run_count += 1
+                continue
+            ls_command_line = [str(aws_cli_path), "s3", "ls", "--summarize", "--recursive", s3_bucket_path]
+            ls_command_line_str = subprocess.list2cmdline(ls_command_line)
+            log.info(ls_command_line_str)
+            ls_result = subprocess.run(ls_command_line, env=env_var, capture_output=True)
+            for line in ls_result.stderr.decode(decoding).splitlines():
+                line = line.strip()
+                if line:
+                    self.warning_out(f"{bucket_name}:{line}")
+            ls_stdout = "".join([c for c in ls_result.stdout.decode(decoding) if c not in " \r\n"])  # remove all whitespace
+            if len(ls_stdout) == 0:
+                self.error_out(f'"{ls_command_line_str}" failed ({ls_stdout=}) - check internet connection')
+            else:
+                ls_parsed = ls_re.search(ls_stdout)
+                if ls_parsed is None:
+                    self.error_out(f"parse error:\n{ls_command_line_str=}\n{ls_stdout=}")
                 else:
-                    self.info_out(f"{bucket_name}")
+                    count += 1
+                    s3_object_count = int(ls_parsed.group(1))
+                    s3_total_size = int(ls_parsed.group(2))
+                    local_size, local_count = get_dir_size(destination)
 
-                # try to find the AWS CLI app
-                # Use sys.executable to reliably locate python and aws CLI in the same directory,
-                # which works for both local venv and installed app scenarios.
-                python_exe = Path(sys.executable)
-                aws_names = ["aws.cmd", "aws.exe", "aws"] if sys.platform == "win32" else ["aws"]
-                aws_candidates = [
-                    (python_exe, python_exe.parent / name)  # same dir as python (venv Scripts/)
-                    for name in aws_names
-                ] + [
-                    (python_exe, python_exe.parent / "Scripts" / name)  # CLIP layout: python at root, scripts in Scripts/
-                    for name in aws_names
-                ] + [
-                    (Path("venv", "Scripts", "python.exe").absolute(), Path("venv", "Scripts", name).absolute())  # local venv from CWD
-                    for name in aws_names
-                ]
-                aws_cli_path = None
-                python_path = None
-                for p, a in aws_candidates:
-                    if p.exists() and a.exists():
-                        aws_cli_path = a
-                        python_path = p
-                        break
-
-                # fall back to whatever is on the system PATH
-                if aws_cli_path is None:
-                    aws_in_path = shutil.which("aws")
-                    if aws_in_path:
-                        aws_cli_path = Path(aws_in_path)
-                        python_path = python_exe
-
-                if aws_cli_path is None:
-                    log.error(f"AWS CLI executable not found ({aws_candidates=})")
-                else:
-                    aws_cli_path = f'"{str(aws_cli_path)}"'  # from Path to str, with quotes for installed app
-                    # AWS CLI app also needs the python executable to be in the path if it's not in the same dir, which happens when this program is installed.
-                    # Make the directory of our python.exe the first in the list so it's found and not any of the others that may or may not be in the PATH.
-                    env_var = os.environ.copy()
-                    env_var["PATH"] = f"{str(python_path.parent)};{env_var.get('PATH', '')}"
-
-                    destination = Path(backup_directory, bucket_name)
-                    os.makedirs(destination, exist_ok=True)
-                    s3_bucket_path = f"s3://{bucket_name}"
-                    # Don't use --delete.  We want to keep 'old' files locally.
-                    sync_command_line = [aws_cli_path, "s3", "sync", s3_bucket_path, f'"{destination.absolute()}"']
-                    if dry_run:
-                        sync_command_line.append("--dryrun")
-                    sync_command_line_str = " ".join(sync_command_line)
-                    log.info(sync_command_line_str)
-
-                    try:
-                        sync_result = subprocess.run(sync_command_line_str, shell=True, env=env_var, capture_output=True)
-                    except FileNotFoundError as e:
-                        self.error_out(f'error executing {" ".join(sync_command_line)} {e}')
-                        return
-
-                    for line in sync_result.stdout.decode(decoding).splitlines():
-                        log.info(f"{bucket_name}:{line.strip()}")
-                    for line in sync_result.stderr.decode(decoding).splitlines():
-                        line = line.strip()
-                        if line:
-                            self.warning_out(f"{bucket_name}:{line}")
-                    if sync_result.returncode != 0:
-                        self.error_out(f"aws s3 sync failed (exit code {sync_result.returncode}) for {bucket_name}")
-
-                    # check the results (skip during dry run - nothing was synced)
-                    if dry_run:
-                        continue
-                    ls_command_line = [aws_cli_path, "s3", "ls", "--summarize", "--recursive", s3_bucket_path]
-                    ls_command_line_str = " ".join(ls_command_line)
-                    log.info(ls_command_line_str)
-                    ls_result = subprocess.run(ls_command_line_str, stdout=subprocess.PIPE, shell=True, env=env_var)
-                    ls_stdout = "".join([c for c in ls_result.stdout.decode(decoding) if c not in " \r\n"])  # remove all whitespace
-                    if len(ls_stdout) == 0:
-                        self.error_out(f'"{ls_command_line_str}" failed ({ls_stdout=}) - check internet connection')
+                    # rough check that the sync worked
+                    if s3_total_size > local_size:
+                        # we're missing files
+                        message = "not all files backed up"
+                        output_routine = self.error_out
+                    elif s3_total_size != local_size:
+                        # Compare size, not number of files, since aws s3 sync does not copy files of zero size.
+                        message = "mismatch"
+                        output_routine = self.warning_out
                     else:
-                        ls_parsed = ls_re.search(ls_stdout)
-                        if ls_parsed is None:
-                            self.error_out(f"parse error:\n{ls_command_line_str=}\n{ls_stdout=}")
-                        else:
-                            count += 1
-                            s3_object_count = int(ls_parsed.group(1))
-                            s3_total_size = int(ls_parsed.group(2))
-                            local_size, local_count = get_dir_size(destination)
+                        message = "match"
+                        output_routine = log.info
+                    output_routine(f"{bucket_name} : {message} (s3_count={s3_object_count}, local_count={local_count}; s3_total_size={s3_total_size}, local_size={local_size})")
 
-                            # rough check that the sync worked
-                            if s3_total_size > local_size:
-                                # we're missing files
-                                message = "not all files backed up"
-                                output_routine = self.error_out
-                            elif s3_total_size != local_size:
-                                # Compare size, not number of files, since aws s3 sync does not copy files of zero size.
-                                message = "mismatch"
-                                output_routine = self.warning_out
-                            else:
-                                message = "match"
-                                output_routine = log.info
-                            output_routine(f"{bucket_name} : {message} (s3_count={s3_object_count}, local_count={local_count}; s3_total_size={s3_total_size}, local_size={local_size})")
-
-        self.info_out(f"{len(buckets)} buckets, {count} backed up, {len(exclusions_no_comments)} excluded")
+        if dry_run:
+            self.info_out(f"{len(buckets)} buckets, {dry_run_count} dry run, {len(exclusions_no_comments)} excluded")
+        else:
+            self.info_out(f"{len(buckets)} buckets, {count} backed up, {len(exclusions_no_comments)} excluded")

--- a/test_bup/test_cli_main.py
+++ b/test_bup/test_cli_main.py
@@ -63,7 +63,7 @@ def test_s3_backup_started_with_s3_flag(mock_get_prefs, mock_balsa, mock_gh, moc
     cli_main(_make_args(s3=True))
 
     mock_engine.start.assert_called_once()
-    mock_engine.join.assert_called_once()
+    mock_engine.wait.assert_called_once()  # QThread uses wait(), not join()
 
 
 @patch("bup.cli.cli_main.S3Backup")

--- a/test_bup/test_print_log.py
+++ b/test_bup/test_print_log.py
@@ -14,7 +14,7 @@ def test_print_log():
     for value in range(start, 0, -1):
         if value < start - 1:
             time.sleep(1)
-        print_log(f"{value-1}" * int(round(50.0 * random.random())))
+        print_log(f"{value - 1}" * int(round(50.0 * random.random())))
 
 
 if is_main():

--- a/test_bup/test_run_backup_widget.py
+++ b/test_bup/test_run_backup_widget.py
@@ -28,6 +28,7 @@ def _make_mock_engine():
     engine.start = MagicMock()
     engine.wait = MagicMock()
     engine.terminate = MagicMock()
+    engine.stop_requested = False  # a MagicMock attribute would be truthy, which reads as "stopped"
     return engine
 
 


### PR DESCRIPTION
## Summary

Fixes from a deep code review of the whole codebase, grouped into four commits:

### CLI (broken behavior)
- `QThread` has `wait()`, not `join()` — CLI runs previously raised `AttributeError` right after starting backups and abandoned the running threads; they now block until completion
- CLI output was silently dropped (queued Qt signals with no event loop to service them) — info/warning/error callbacks are now invoked directly in CLI mode
- Running without `-t`/`-p`/`-r` no longer erases the saved GitHub token / AWS profile / region (the pref library persists `None` assignments)
- `--region` is now actually applied; `--version` works in any position; `--dellog` is a proper flag; `-e` can clear exclusions and works with `-a`

### Security
- GitHub auth for clone/pull moves from token-in-URL to git's `GIT_CONFIG_*` environment (`http.extraHeader`), so the token is never persisted into each backup's `.git/config`; token URLs written by older versions are scrubbed on the next pull, and git error text is redacted before reaching the GUI/logs/Sentry (requires git >= 2.31)
- AWS CLI subprocess calls use argument lists instead of `shell=True` string commands
- README documents that credentials are stored unencrypted in the prefs database

### Cross-platform / robustness
- `os.pathsep` instead of hard-coded `;` when prepending to `PATH` (was breaking macOS/Linux)
- Correct `\?\UNC\` long-path prefix for UNC paths; `shutil.rmtree` `onerror` → `onexc`; saner `mkdirs` retry budget
- S3: AWS CLI lookup hoisted out of the per-bucket loop, failed syncs skip verification and aren't counted, dry runs get their own count, `ls` stderr surfaced as warnings

### GUI
- A stopped run no longer resets the auto-backup countdown as if it completed
- O(1) display appends instead of re-rendering the whole 1000-line buffer per message; debounced exclusion writes with flush-on-close
- Locale-proof `QSpinBox.value()` reads; first automatic backup announces itself

## Testing
- All 56 tests pass; flake8 clean; Black-formatted
- Live-verified: threaded CLI-mode backup delivers output and `wait()`s correctly; `--version` in any position; real clone + scrub + pull through the new env-based git credential path; `git config --list` confirms git honors `GIT_CONFIG_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)