### PR TITLE
Add GitHub Actions CI (flake8 + pytest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-cov flake8
+
+      - name: Lint
+        run: flake8 --ignore=E402,F401,W503,E203,E501 bup test_bup
+
+      - name: Test
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          QT_QPA_PLATFORM: offscreen
+        run: pytest --cov=bup --cov-report=term test_bup


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs on every PR and on pushes to main:

- **windows-latest** with **Python 3.13** — matches the primary dev platform (the batch-script workflow, `robust_os_calls.py`, and the AWS CLI lookup are all Windows-centric)
- **Lint:** flake8 with the project's ignore list (E402, F401, W503, E203, E501 — same as `run_flake8.bat`)
- **Test:** full pytest suite with coverage; `QT_QPA_PLATFORM=offscreen` keeps the PyQt5 GUI tests headless
- Dependencies come from `pyproject.toml` via `pip install -e .` (plus pytest/pytest-cov/flake8), with pip caching keyed on `pyproject.toml`

Motivation: the repo previously had no CI, so bugs like the `QThread.join()` crash fixed in #21 could only be caught by someone running tests locally. This PR itself exercises the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)