### PR TITLE
Fix pypi.bat: fail fast instead of uploading after a broken build

### DIFF
--- a/bup/__version__.py
+++ b/bup/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.11"
+__version__ = "0.11.12"
 __application_name__ = "bup"
 __title__ = __application_name__
 __author__ = "abel"

--- a/pypi.bat
+++ b/pypi.bat
@@ -1,4 +1,27 @@
+setlocal
+
 call build.bat
+
+if not exist dist\*.whl (
+    echo ERROR: build failed - no wheel found in dist
+    exit /b 1
+)
+
 call venv\Scripts\activate.bat
+
+twine check --strict dist/*
+if errorlevel 1 (
+    echo ERROR: twine check failed - not uploading
+    call deactivate
+    exit /b 1
+)
+
 twine upload dist/*
+if errorlevel 1 (
+    echo ERROR: twine upload failed
+    call deactivate
+    exit /b 1
+)
+
 call deactivate
+exit /b 0


### PR DESCRIPTION
## Summary
- `pypi.bat` previously chained build → upload with no error handling: if the build failed, `twine upload dist/*` still ran against an empty or stale `dist` directory.
- The script now verifies a wheel exists in `dist` after the build, runs `twine check --strict` before uploading, and exits nonzero (with a clear message) if any step fails.

## Testing
- Ran the full script with the upload line stubbed: build succeeds, `twine check --strict` passes on both the wheel and sdist, exit code 0.
- Simulated a failed build (removed `dist`): script exits 1 with "build failed - no wheel found in dist" before reaching twine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)