### PR TITLE
Remove redundant --permission-mode flag from run_claude.bat

### DIFF
--- a/run_claude.bat
+++ b/run_claude.bat
@@ -1,1 +1,1 @@
-claude --permission-mode acceptEdits --dangerously-skip-permissions
+claude --dangerously-skip-permissions


### PR DESCRIPTION
## Summary
- `--dangerously-skip-permissions` supersedes `--permission-mode acceptEdits`, so the latter is dead weight; the script now passes only the skip-permissions flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)