### PR TITLE
Check that the AWS CLI running S3 backups is the latest; show its version in About

### DIFF
--- a/bup/aws_cli.py
+++ b/bup/aws_cli.py
@@ -118,4 +118,4 @@ def check_aws_cli_version(installed_version: Optional[str], latest_version: Opti
         return "warning", f"could not compare AWS CLI versions (installed: {installed_version}, latest: {latest_version})"
     if installed < latest:
         return "warning", f'AWS CLI {installed_version} is not the latest ({latest_version}) - upgrade with "pip install --upgrade awscli"'
-    return "info", f"AWS CLI {installed_version} is up to date"
+    return "info", f"AWS CLI {installed_version} is up to date (latest: {latest_version})"

--- a/bup/aws_cli.py
+++ b/bup/aws_cli.py
@@ -1,0 +1,121 @@
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Optional, Tuple
+
+from balsa import get_logger
+
+from bup import __application_name__
+
+log = get_logger(__application_name__)
+
+decoding = "utf-8"
+
+awscli_pypi_url = "https://pypi.org/pypi/awscli/json"
+
+
+def find_aws_cli() -> Tuple[Optional[Path], Optional[Path]]:
+    """
+    Locate the AWS CLI executable and the python executable it should run with.
+    Use sys.executable to reliably locate python and aws CLI in the same directory,
+    which works for both local venv and installed app scenarios.
+    :return: (aws_cli_path, python_path), or (None, None) if not found
+    """
+    python_exe = Path(sys.executable)
+    aws_names = ["aws.cmd", "aws.exe", "aws"] if sys.platform == "win32" else ["aws"]
+    aws_candidates = (
+        [(python_exe, python_exe.parent / name) for name in aws_names]  # same dir as python (venv Scripts/)
+        + [(python_exe, python_exe.parent / "Scripts" / name) for name in aws_names]  # CLIP layout: python at root, scripts in Scripts/
+        + [(Path("venv", "Scripts", "python.exe").absolute(), Path("venv", "Scripts", name).absolute()) for name in aws_names]  # local venv from CWD
+    )
+    for p, a in aws_candidates:
+        if p.exists() and a.exists():
+            return a, p
+
+    # fall back to whatever is on the system PATH
+    aws_in_path = shutil.which("aws")
+    if aws_in_path:
+        return Path(aws_in_path), python_exe
+
+    log.error(f"AWS CLI executable not found ({aws_candidates=})")
+    return None, None
+
+
+def make_aws_cli_env(python_path: Path) -> dict:
+    """
+    Environment for running the AWS CLI. The AWS CLI needs the python executable to be in the PATH if it's not in the same dir, which happens
+    when this program is installed. Make the directory of our python.exe the first in the list so it's found and not any of the others that
+    may or may not be in the PATH.
+    """
+    env_var = os.environ.copy()
+    env_var["PATH"] = f"{str(python_path.parent)}{os.pathsep}{env_var.get('PATH', '')}"
+    return env_var
+
+
+def get_aws_cli_version(aws_cli_path: Path, env_var: dict) -> Optional[str]:
+    """
+    Version of the given AWS CLI executable (e.g. "1.42.35"), from "aws --version".
+    :return: the version string, or None if it could not be determined
+    """
+    command_line = [str(aws_cli_path), "--version"]
+    try:
+        result = subprocess.run(command_line, env=env_var, capture_output=True, timeout=60.0)
+    except (OSError, subprocess.SubprocessError) as e:
+        log.warning(f'error executing {" ".join(command_line)} : {e}')
+        return None
+    # output looks like "aws-cli/1.42.35 Python/3.13.0 Windows/11 botocore/1.40.35" (older AWS CLI versions write it to stderr, newer to stdout)
+    output = f"{result.stdout.decode(decoding, errors='replace')} {result.stderr.decode(decoding, errors='replace')}"
+    match = re.search(r"aws-cli/(\S+)", output)
+    if match is None:
+        log.warning(f'could not parse AWS CLI version from "{output.strip()}"')
+        return None
+    return match.group(1)
+
+
+def get_latest_awscli_version(timeout: float = 10.0) -> Optional[str]:
+    """
+    Latest awscli version published on PyPI (the AWS CLI is pip-installed as the awscli package).
+    :return: the version string, or None if it could not be determined (e.g. offline)
+    """
+    try:
+        with urllib.request.urlopen(awscli_pypi_url, timeout=timeout) as response:
+            package_info = json.load(response)
+        return package_info["info"]["version"]
+    except (OSError, ValueError, KeyError) as e:
+        # OSError covers URLError and timeouts, ValueError covers JSONDecodeError
+        log.info(f"could not get latest awscli version from {awscli_pypi_url} : {e}")
+        return None
+
+
+def parse_version(version: str) -> Optional[Tuple[int, ...]]:
+    """
+    Parse a dotted numeric version string (e.g. "1.42.35") into a comparable tuple of ints.
+    :return: the tuple, or None if the string is not a dotted numeric version
+    """
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError:
+        return None
+
+
+def check_aws_cli_version(installed_version: Optional[str], latest_version: Optional[str]) -> Tuple[str, str]:
+    """
+    Check that the installed AWS CLI is the latest available.
+    :return: (level, message) where level is "warning" or "info"
+    """
+    if installed_version is None:
+        return "warning", "could not determine the installed AWS CLI version"
+    if latest_version is None:
+        return "warning", f"could not determine the latest AWS CLI version (installed: {installed_version})"
+    installed = parse_version(installed_version)
+    latest = parse_version(latest_version)
+    if installed is None or latest is None:
+        return "warning", f"could not compare AWS CLI versions (installed: {installed_version}, latest: {latest_version})"
+    if installed < latest:
+        return "warning", f'AWS CLI {installed_version} is not the latest ({latest_version}) - upgrade with "pip install --upgrade awscli"'
+    return "info", f"AWS CLI {installed_version} is up to date"

--- a/bup/gui/about.py
+++ b/bup/gui/about.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import QVBoxLayout, QWidget, QTextBrowser
 from balsa import get_logger
 
 from bup import __url__, __author_url__, __version__, __application_name__
-from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version
+from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version, get_latest_awscli_version
 
 log = get_logger(__application_name__)
 
@@ -12,9 +12,13 @@ log = get_logger(__application_name__)
 def get_aws_cli_version_text() -> str:
     aws_cli_path, python_path = find_aws_cli()
     if aws_cli_path is None:
-        return "not found"
-    aws_cli_version = get_aws_cli_version(aws_cli_path, make_aws_cli_env(python_path))
-    return aws_cli_version if aws_cli_version is not None else "unknown"
+        installed_text = "not found"
+    else:
+        aws_cli_version = get_aws_cli_version(aws_cli_path, make_aws_cli_env(python_path))
+        installed_text = aws_cli_version if aws_cli_version is not None else "unknown"
+    latest_version = get_latest_awscli_version()
+    latest_text = latest_version if latest_version is not None else "unknown"
+    return f"{installed_text} (latest: {latest_text})"
 
 
 class BupAbout(QWidget):

--- a/bup/gui/about.py
+++ b/bup/gui/about.py
@@ -4,8 +4,17 @@ from PyQt5.QtWidgets import QVBoxLayout, QWidget, QTextBrowser
 from balsa import get_logger
 
 from bup import __url__, __author_url__, __version__, __application_name__
+from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version
 
 log = get_logger(__application_name__)
+
+
+def get_aws_cli_version_text() -> str:
+    aws_cli_path, python_path = find_aws_cli()
+    if aws_cli_path is None:
+        return "not found"
+    aws_cli_version = get_aws_cli_version(aws_cli_path, make_aws_cli_env(python_path))
+    return aws_cli_version if aws_cli_version is not None else "unknown"
 
 
 class BupAbout(QWidget):
@@ -28,6 +37,7 @@ class BupAbout(QWidget):
         if license_path is not None and license_path.exists() and license_path.is_file():
 
             about_text = f"### BUP ({__version__})\n\n"
+            about_text += f"AWS CLI version: {get_aws_cli_version_text()}\n\n"
             about_text += license_path.read_text()
             about_text += "\n---\n"
             about_text += f"\nsource code: [{__url__}]({__url__})\n"

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -1,10 +1,8 @@
 import logging
-import shutil
 import subprocess
-import sys
 import os
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Tuple
 
 from awsimple import S3Access
 from botocore.exceptions import BotoCoreError, ClientError
@@ -14,6 +12,7 @@ logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
 from bup import __application_name__, BupBase, BackupTypes, get_preferences, ExclusionPreferences
+from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version, get_latest_awscli_version, check_aws_cli_version
 
 log = get_logger(__application_name__)
 
@@ -66,33 +65,6 @@ def compare_backup_sizes(s3_total_size: int, local_size: int) -> Tuple[str, str]
         return "info", "match"
 
 
-def find_aws_cli() -> Tuple[Optional[Path], Optional[Path]]:
-    """
-    Locate the AWS CLI executable and the python executable it should run with.
-    Use sys.executable to reliably locate python and aws CLI in the same directory,
-    which works for both local venv and installed app scenarios.
-    :return: (aws_cli_path, python_path), or (None, None) if not found
-    """
-    python_exe = Path(sys.executable)
-    aws_names = ["aws.cmd", "aws.exe", "aws"] if sys.platform == "win32" else ["aws"]
-    aws_candidates = (
-        [(python_exe, python_exe.parent / name) for name in aws_names]  # same dir as python (venv Scripts/)
-        + [(python_exe, python_exe.parent / "Scripts" / name) for name in aws_names]  # CLIP layout: python at root, scripts in Scripts/
-        + [(Path("venv", "Scripts", "python.exe").absolute(), Path("venv", "Scripts", name).absolute()) for name in aws_names]  # local venv from CWD
-    )
-    for p, a in aws_candidates:
-        if p.exists() and a.exists():
-            return a, p
-
-    # fall back to whatever is on the system PATH
-    aws_in_path = shutil.which("aws")
-    if aws_in_path:
-        return Path(aws_in_path), python_exe
-
-    log.error(f"AWS CLI executable not found ({aws_candidates=})")
-    return None, None
-
-
 class S3Backup(BupBase):
 
     backup_type = BackupTypes.S3
@@ -135,10 +107,11 @@ class S3Backup(BupBase):
             self.error_out("AWS CLI executable not found - S3 backup cannot run")
             return
 
-        # The AWS CLI app also needs the python executable to be in the path if it's not in the same dir, which happens when this program is installed.
-        # Make the directory of our python.exe the first in the list so it's found and not any of the others that may or may not be in the PATH.
-        env_var = os.environ.copy()
-        env_var["PATH"] = f"{str(python_path.parent)}{os.pathsep}{env_var.get('PATH', '')}"
+        env_var = make_aws_cli_env(python_path)
+
+        # check that the AWS CLI doing the backups is the latest available (warn but proceed - an outdated CLI can still back up)
+        aws_cli_version_level, aws_cli_version_message = check_aws_cli_version(get_aws_cli_version(aws_cli_path, env_var), get_latest_awscli_version())
+        {"warning": self.warning_out, "info": self.info_out}[aws_cli_version_level](aws_cli_version_message)
 
         try:
             buckets = s3_access.bucket_list()

--- a/test_bup/test_aws_cli.py
+++ b/test_bup/test_aws_cli.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from bup.aws_cli import get_aws_cli_version, get_latest_awscli_version, parse_version, check_aws_cli_version
+
+
+def _make_completed_process(stdout: bytes = b"", stderr: bytes = b"") -> MagicMock:
+    completed_process = MagicMock()
+    completed_process.stdout = stdout
+    completed_process.stderr = stderr
+    return completed_process
+
+
+def test_get_aws_cli_version_from_stdout():
+    with patch("bup.aws_cli.subprocess.run", return_value=_make_completed_process(stdout=b"aws-cli/1.42.35 Python/3.13.0 Windows/11 botocore/1.40.35")):
+        assert get_aws_cli_version(Path("aws"), {}) == "1.42.35"
+
+
+def test_get_aws_cli_version_from_stderr():
+    # older AWS CLI versions write --version output to stderr
+    with patch("bup.aws_cli.subprocess.run", return_value=_make_completed_process(stderr=b"aws-cli/1.16.0 Python/3.6.0 Windows/10 botocore/1.12.0")):
+        assert get_aws_cli_version(Path("aws"), {}) == "1.16.0"
+
+
+def test_get_aws_cli_version_unparseable_output():
+    with patch("bup.aws_cli.subprocess.run", return_value=_make_completed_process(stdout=b"something unexpected")):
+        assert get_aws_cli_version(Path("aws"), {}) is None
+
+
+def test_get_aws_cli_version_executable_not_found():
+    with patch("bup.aws_cli.subprocess.run", side_effect=FileNotFoundError("no such file")):
+        assert get_aws_cli_version(Path("aws"), {}) is None
+
+
+def test_get_latest_awscli_version():
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"info": {"version": "1.43.0"}}'
+    with patch("bup.aws_cli.urllib.request.urlopen", return_value=response):
+        assert get_latest_awscli_version() == "1.43.0"
+
+
+def test_get_latest_awscli_version_offline():
+    with patch("bup.aws_cli.urllib.request.urlopen", side_effect=OSError("no network")):
+        assert get_latest_awscli_version() is None
+
+
+def test_parse_version():
+    assert parse_version("1.42.35") == (1, 42, 35)
+    assert parse_version("2.0") == (2, 0)
+    assert parse_version("1.2.3rc1") is None
+    assert parse_version("") is None
+
+
+def test_check_aws_cli_version_up_to_date():
+    level, message = check_aws_cli_version("1.42.35", "1.42.35")
+    assert level == "info"
+    assert "up to date" in message
+
+
+def test_check_aws_cli_version_newer_than_latest_is_info():
+    level, _unused_message = check_aws_cli_version("1.42.36", "1.42.35")
+    assert level == "info"
+
+
+def test_check_aws_cli_version_outdated():
+    level, message = check_aws_cli_version("1.42.34", "1.42.35")
+    assert level == "warning"
+    assert "not the latest" in message
+    assert "1.42.34" in message
+    assert "1.42.35" in message
+
+
+def test_check_aws_cli_version_installed_unknown():
+    level, message = check_aws_cli_version(None, "1.42.35")
+    assert level == "warning"
+    assert "installed" in message
+
+
+def test_check_aws_cli_version_latest_unknown():
+    level, message = check_aws_cli_version("1.42.35", None)
+    assert level == "warning"
+    assert "latest" in message
+
+
+def test_check_aws_cli_version_unparseable():
+    level, message = check_aws_cli_version("1.42.35", "not-a-version")
+    assert level == "warning"
+    assert "could not compare" in message

--- a/test_bup/test_aws_cli.py
+++ b/test_bup/test_aws_cli.py
@@ -55,6 +55,7 @@ def test_check_aws_cli_version_up_to_date():
     level, message = check_aws_cli_version("1.42.35", "1.42.35")
     assert level == "info"
     assert "up to date" in message
+    assert "latest: 1.42.35" in message
 
 
 def test_check_aws_cli_version_newer_than_latest_is_info():

--- a/test_bup/test_s3_backup.py
+++ b/test_bup/test_s3_backup.py
@@ -2,12 +2,23 @@ import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from bup import UITypes
 from bup.s3_backup import S3Backup, compare_backup_sizes, get_bucket_size, get_dir_size
 
 fake_aws_cli = (Path("aws"), Path("python"))
+
+
+@pytest.fixture(autouse=True)
+def up_to_date_aws_cli():
+    # keep run() tests from shelling out to a real AWS CLI or hitting PyPI for the version check
+    with (
+        patch("bup.s3_backup.get_aws_cli_version", return_value="1.0.0"),
+        patch("bup.s3_backup.get_latest_awscli_version", return_value="1.0.0"),
+    ):
+        yield
 
 
 class FakePaginator:
@@ -164,6 +175,26 @@ def test_failed_sync_surfaces_error_and_skips_verification(mock_get_prefs, mock_
 
     assert any("aws s3 sync failed" in e for e in errors)
     assert any("0 backed up" in i for i in infos)
+
+
+@patch("bup.s3_backup.find_aws_cli", return_value=fake_aws_cli)
+@patch("bup.s3_backup.ExclusionPreferences")
+@patch("bup.s3_backup.S3Access")
+@patch("bup.s3_backup.get_preferences")
+def test_outdated_aws_cli_surfaces_warning(mock_get_prefs, mock_s3_access, mock_exclusions, mock_find_aws_cli, tmp_path):
+    mock_get_prefs.return_value = _make_preferences(tmp_path, dry_run=True)
+    mock_s3_access.return_value.bucket_list.return_value = []
+    mock_exclusions.return_value.get_no_comments.return_value = []
+    warnings = []
+    backup = _make_backup(warning=warnings.append)
+
+    with (
+        patch("bup.s3_backup.get_aws_cli_version", return_value="1.0.0"),
+        patch("bup.s3_backup.get_latest_awscli_version", return_value="1.1.0"),
+    ):
+        backup.run()
+
+    assert any("not the latest" in w for w in warnings)
 
 
 @patch("bup.s3_backup.get_bucket_size")


### PR DESCRIPTION
## Summary
- New `bup/aws_cli.py` module: `find_aws_cli` (moved from `s3_backup.py`), `get_aws_cli_version` (runs `aws --version` and parses the output, checking both stdout and stderr since older CLIs print to stderr), `get_latest_awscli_version` (PyPI JSON API for the `awscli` package, stdlib urllib, 10s timeout), and `check_aws_cli_version` (pure comparison returning a level/message pair).
- `S3Backup.run` checks the CLI version right after locating the executable and emits a warning if it is outdated (or if either version cannot be determined, e.g. offline) — the backup still proceeds either way.
- The GUI About tab now shows the AWS CLI version under the title line.
- The PATH-priming env setup in `S3Backup.run` moved into `make_aws_cli_env` so the About tab can run the CLI the same way.

## Notes
- The check is only wired into the S3 backup because it is the only backup type that shells out to the AWS CLI (DynamoDB uses awsimple/boto3 directly).
- End-to-end sanity check against the real venv: correctly reported `AWS CLI 1.44.53 is not the latest (1.46.0)`.
- The About tab runs `aws --version` synchronously during construction, which adds roughly a second to GUI startup.

## Testing
- New `test_bup/test_aws_cli.py` covering version parsing (stdout/stderr/unparseable/missing executable), the PyPI lookup (success/offline), and all `check_aws_cli_version` outcomes.
- `test_s3_backup.py`: autouse fixture stubs the version functions so `run()` tests stay offline; new test asserts an outdated CLI surfaces a warning through the backup run.
- 89 tests pass; flake8 clean with the project ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)