### PR TITLE
Add a Log tab with the detailed application log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ python -m bup <path> -s    # CLI with S3 backup
 
 **Preferences:** SQLite-backed via the `pref` library with `attrs` data classes. CLI and GUI have separate preference stores. Exclusion lists (per backup type) support comment lines starting with `#`.
 
-**GUI:** PyQt5 tabbed dialog (`BupDialog`) with `RunBackupWidget`, `PreferencesWidget`, and `BupAbout` tabs.
+**GUI:** PyQt5 tabbed dialog (`BupDialog`) with `RunBackupWidget`, `PreferencesWidget`, `LogWidget` (detailed application log via a logging handler), and `BupAbout` tabs.
 
 ## Code Style
 

--- a/bup/arguments.py
+++ b/bup/arguments.py
@@ -38,6 +38,7 @@ def arguments():
         parser.add_argument("-r", "--region", help="AWS region (uses the default AWS region if not given)")
         parser.add_argument("-t", "--token", help="github token (saved and used on subsequent runs)")
         parser.add_argument("--dry_run", action="store_true", default=False, help="displays operations that would be performed using the specified command without actually running them")
+        parser.add_argument("--size_only", action="store_true", default=False, help="AWS S3 sync compares file size only, not timestamps (aws s3 sync --size-only)")
         parser.add_argument(f"--{version_string}", action="store_true", default=False, help="display version and exit")
         parser.add_argument("-v", f"--{verbose_arg_string}", dest=verbose_arg_string, action="store_true", default=False, help="set verbose")
         parser.add_argument("-l", f"--{log_dir_arg_string}", dest=log_dir_arg_string, help="log dir")

--- a/bup/bup_base.py
+++ b/bup/bup_base.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Callable
 
 from PyQt5.QtCore import QThread, pyqtSignal
@@ -36,6 +37,17 @@ class BupBase(QThread):
         self.error_count = 0
         super().start(*args, **kwargs)
 
+    def run(self):
+        # QThreads aren't registered with Python's threading module by name, so log records would show a meaningless
+        # thread name like "Dummy-25" - name the thread after this backup class (guard so a direct run() call in
+        # tests doesn't rename the main thread)
+        if threading.current_thread() is not threading.main_thread():
+            threading.current_thread().name = type(self).__name__
+        self.run_backup()
+
+    def run_backup(self):
+        raise NotImplementedError
+
     def request_stop(self):
         self._stop_requested = True
 
@@ -51,9 +63,14 @@ class BupBase(QThread):
         else:
             self.info_out_signal.emit(s)
 
+    def _log_extra(self) -> dict:
+        # stamp the record with this engine's backup type so the GUI log tab can route it to the right pane
+        # (the record's own source location is this file, not the backup module the message came from)
+        return {"backup_type": self.backup_type}
+
     def _info_out(self, s: str):
         # hooked up to the signal for threading
-        log.info(s)
+        log.info(s, extra=self._log_extra())
         self.caller_info_out(s)
 
     def warning_out(self, s: str):
@@ -65,7 +82,7 @@ class BupBase(QThread):
 
     def _warning_out(self, s: str):
         # hooked up to the signal for threading
-        log.warning(s)
+        log.warning(s, extra=self._log_extra())
         self.caller_warning_out(s)
 
     def error_out(self, s: str):
@@ -78,5 +95,5 @@ class BupBase(QThread):
     def _error_out(self, s: str):
         # hooked up to the signal for threading
         self.error_count += 1
-        log.error(s)
+        log.error(s, extra=self._log_extra())
         self.caller_error_out(s)

--- a/bup/cli/cli_main.py
+++ b/bup/cli/cli_main.py
@@ -33,7 +33,7 @@ def cli_main(args):
 
     preferences = get_preferences(ui_type)
     preferences.backup_directory = args.path  # backup classes will read the preferences DB directly
-    set_detailed_file_logging(preferences.detailed_log_directory)  # one detailed log file per backup type, if configured
+    set_detailed_file_logging(preferences.detailed_log_directory, preferences.detailed_log_file_size_limit_mb)  # one detailed log file per backup type, if configured
     # only overwrite saved values when explicitly given on the command line
     if args.token is not None:
         preferences.github_token = args.token

--- a/bup/cli/cli_main.py
+++ b/bup/cli/cli_main.py
@@ -3,6 +3,7 @@ import sys
 from balsa import Balsa, get_logger
 
 from bup import __application_name__, __author__, __version__, S3Backup, DynamoDBBackup, GithubBackup, get_preferences, UITypes, ExclusionPreferences, BackupTypes
+from bup.log_routing import set_detailed_file_logging
 
 log = get_logger(__application_name__)
 
@@ -32,6 +33,7 @@ def cli_main(args):
 
     preferences = get_preferences(ui_type)
     preferences.backup_directory = args.path  # backup classes will read the preferences DB directly
+    set_detailed_file_logging(preferences.detailed_log_directory)  # one detailed log file per backup type, if configured
     # only overwrite saved values when explicitly given on the command line
     if args.token is not None:
         preferences.github_token = args.token

--- a/bup/cli/cli_main.py
+++ b/bup/cli/cli_main.py
@@ -42,6 +42,7 @@ def cli_main(args):
     if args.region is not None:
         preferences.aws_region = args.region
     preferences.dry_run = args.dry_run
+    preferences.s3_size_only = args.size_only
 
     # Set the exclusions for the selected backup type(s).  The values are stored for subsequent runs.
     # An explicitly empty -e (no values) clears the stored exclusions.

--- a/bup/dynamodb_backup.py
+++ b/bup/dynamodb_backup.py
@@ -21,7 +21,7 @@ class DynamoDBBackup(BupBase):
 
     backup_type = BackupTypes.DynamoDB
 
-    def run(self):
+    def run_backup(self):
         preferences = get_preferences(self.ui_type)
         backup_directory = preferences.backup_directory
         dry_run = preferences.dry_run

--- a/bup/github_backup.py
+++ b/bup/github_backup.py
@@ -44,7 +44,7 @@ class GithubBackup(BupBase):
             s = s.replace(self._github_token, "***")
         return s
 
-    def run(self):
+    def run_backup(self):
         if shutil.which("git") is None:
             self.error_out("git executable not found in PATH - GitHub backup cannot run")
             return

--- a/bup/gui/__init__.py
+++ b/bup/gui/__init__.py
@@ -1,6 +1,7 @@
 from .preferences_widget import PreferencesWidget, get_gui_preferences
 from .about import BupAbout
 from .gui_icon import get_icon_path
+from .log_widget import LogWidget
 from .run_backup_widget import RunBackupWidget
 from .bup_dialog import BupDialog
 from .gui_main import gui_main

--- a/bup/gui/bup_dialog.py
+++ b/bup/gui/bup_dialog.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QCloseEvent, QIcon
 from PyQt5.QtCore import QTimer, Qt
 
 from bup import __application_name__, __version__, __author__, get_preferences, UITypes
-from bup.gui import PreferencesWidget, RunBackupWidget, BupAbout, get_icon_path
+from bup.gui import PreferencesWidget, RunBackupWidget, LogWidget, BupAbout, get_icon_path
 
 
 class BupDialog(QDialog):
@@ -32,10 +32,12 @@ class BupDialog(QDialog):
 
         self.run_backup_widget = RunBackupWidget()
         self.preferences_widget = PreferencesWidget()
+        self.log_widget = LogWidget()
         self.about_widget = BupAbout()
 
         self.tab_widget.addTab(self.run_backup_widget, "Backup")
         self.tab_widget.addTab(self.preferences_widget, "Preferences")
+        self.tab_widget.addTab(self.log_widget, "Log")
         self.tab_widget.addTab(self.about_widget, "About")
 
         preferences = get_preferences(UITypes.gui)
@@ -101,6 +103,7 @@ class BupDialog(QDialog):
         self.autobackup_timer.stop()
         self.run_backup_widget.stop()
         self.run_backup_widget.wait_for_threads(5000)
+        self.log_widget.detach()
         self.run_backup_widget.save_state()
         preferences = get_preferences(UITypes.gui)
         preferences.width = self.width()

--- a/bup/gui/bup_dialog.py
+++ b/bup/gui/bup_dialog.py
@@ -104,6 +104,7 @@ class BupDialog(QDialog):
         self.run_backup_widget.stop()
         self.run_backup_widget.wait_for_threads(5000)
         self.log_widget.detach()
+        self.log_widget.save_state()
         self.run_backup_widget.save_state()
         preferences = get_preferences(UITypes.gui)
         preferences.width = self.width()

--- a/bup/gui/gui_main.py
+++ b/bup/gui/gui_main.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv, find_dotenv
 from tobool import to_bool_strict
 
 from bup import __application_name__, __author__
+from bup.log_routing import set_detailed_file_logging
 from bup.gui import BupDialog, get_gui_preferences
 
 load_dotenv(find_dotenv())
@@ -24,6 +25,8 @@ def gui_main():
             sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0, profiles_sample_rate=1.0)
             balsa.sentry_dsn = sentry_dsn
     balsa.init_logger()
+
+    set_detailed_file_logging(get_gui_preferences().detailed_log_directory)
 
     app = QApplication([])
     bup_gui = BupDialog()

--- a/bup/gui/gui_main.py
+++ b/bup/gui/gui_main.py
@@ -26,7 +26,8 @@ def gui_main():
             balsa.sentry_dsn = sentry_dsn
     balsa.init_logger()
 
-    set_detailed_file_logging(get_gui_preferences().detailed_log_directory)
+    gui_preferences = get_gui_preferences()
+    set_detailed_file_logging(gui_preferences.detailed_log_directory, gui_preferences.detailed_log_file_size_limit_mb)
 
     app = QApplication([])
     bup_gui = BupDialog()

--- a/bup/gui/log_widget.py
+++ b/bup/gui/log_widget.py
@@ -1,0 +1,71 @@
+import logging
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtGui import QFontDatabase
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, QPushButton
+from balsa import get_logger
+
+from bup import __application_name__
+
+log = get_logger(__application_name__)
+
+max_log_lines = 10000
+
+log_line_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(threadName)s %(message)s"
+
+
+class QtLogEmitter(QObject):
+    log_line_signal = pyqtSignal(str)
+
+
+class QtLogHandler(logging.Handler):
+    """
+    logging handler that forwards formatted log records to the GUI via a Qt signal
+    (backups log from worker QThreads, and Qt widgets may only be touched from the GUI thread - the signal connection handles the thread hop)
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.emitter = QtLogEmitter()
+        self.setFormatter(logging.Formatter(log_line_format))
+
+    def emit(self, record: logging.LogRecord):
+        self.emitter.log_line_signal.emit(self.format(record))
+
+
+class LogWidget(QWidget):
+    """
+    "Log" tab - detailed application log (e.g. the full AWS CLI command lines), fed by all log records of this application's logger
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setLayout(QVBoxLayout())
+
+        self.controls_widget = QWidget()
+        self.controls_layout = QHBoxLayout()
+        self.controls_widget.setLayout(self.controls_layout)
+        self.clear_button = QPushButton("Clear")
+        self.controls_layout.addWidget(self.clear_button)
+        self.controls_layout.addStretch()
+
+        self.log_text_box = QPlainTextEdit()
+        self.log_text_box.setReadOnly(True)
+        self.log_text_box.setMaximumBlockCount(max_log_lines)  # FIFO - drops the oldest lines
+        self.log_text_box.setLineWrapMode(QPlainTextEdit.NoWrap)
+        self.log_text_box.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
+        self.clear_button.clicked.connect(self.log_text_box.clear)
+
+        self.layout().addWidget(self.controls_widget)
+        self.layout().addWidget(self.log_text_box)
+
+        self.log_handler = QtLogHandler()
+        self.log_handler.setLevel(logging.DEBUG)  # display everything the logger's own level lets through (e.g. DEBUG with the verbose preference)
+        self.log_handler.emitter.log_line_signal.connect(self.log_text_box.appendPlainText)
+        logging.getLogger(__application_name__).addHandler(self.log_handler)
+
+    def detach(self):
+        """
+        Stop capturing log records. Call before the widget is destroyed so the handler doesn't write into a dead widget.
+        """
+        logging.getLogger(__application_name__).removeHandler(self.log_handler)

--- a/bup/gui/log_widget.py
+++ b/bup/gui/log_widget.py
@@ -1,12 +1,12 @@
 import logging
-from enum import Enum
 
 from PyQt5.QtCore import QObject, pyqtSignal, Qt
 from PyQt5.QtGui import QFontDatabase
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, QPushButton, QGroupBox, QSplitter
 from balsa import get_logger
 
-from bup import __application_name__, BackupTypes
+from bup import __application_name__
+from bup.log_routing import LogSources, get_log_source, log_line_format
 from bup.gui import get_gui_preferences
 
 log = get_logger(__application_name__)
@@ -14,39 +14,6 @@ log = get_logger(__application_name__)
 max_log_lines = 10000
 
 minimum_pane_height = 50  # pixels
-
-log_line_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(threadName)s %(message)s"
-
-
-class LogSources(Enum):
-    s3 = "AWS S3"
-    dynamodb = "DynamoDB"
-    github = "GitHub"
-    application = "Application"
-
-
-# records stamped with a backup type by BupBase (the info_out/warning_out/error_out path, whose records all originate in bup_base.py)
-log_sources_by_backup_type = {
-    BackupTypes.S3: LogSources.s3,
-    BackupTypes.DynamoDB: LogSources.dynamodb,
-    BackupTypes.github: LogSources.github,
-}
-
-# records logged directly (not via BupBase) are routed by the source file they were logged from
-# (all of bup logs to the same application logger)
-log_sources_by_filename = {
-    "s3_backup.py": LogSources.s3,
-    "aws_cli.py": LogSources.s3,
-    "dynamodb_backup.py": LogSources.dynamodb,
-    "github_backup.py": LogSources.github,
-}
-
-
-def get_log_source(record: logging.LogRecord) -> LogSources:
-    backup_type = getattr(record, "backup_type", None)
-    if backup_type in log_sources_by_backup_type:
-        return log_sources_by_backup_type[backup_type]
-    return log_sources_by_filename.get(record.filename, LogSources.application)
 
 
 class QtLogEmitter(QObject):

--- a/bup/gui/log_widget.py
+++ b/bup/gui/log_widget.py
@@ -6,7 +6,7 @@ from PyQt5.QtGui import QFontDatabase
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, QPushButton, QGroupBox, QSplitter
 from balsa import get_logger
 
-from bup import __application_name__
+from bup import __application_name__, BackupTypes
 from bup.gui import get_gui_preferences
 
 log = get_logger(__application_name__)
@@ -25,7 +25,15 @@ class LogSources(Enum):
     application = "Application"
 
 
-# records are routed to a pane by the source file they were logged from (all of bup logs to the same application logger)
+# records stamped with a backup type by BupBase (the info_out/warning_out/error_out path, whose records all originate in bup_base.py)
+log_sources_by_backup_type = {
+    BackupTypes.S3: LogSources.s3,
+    BackupTypes.DynamoDB: LogSources.dynamodb,
+    BackupTypes.github: LogSources.github,
+}
+
+# records logged directly (not via BupBase) are routed by the source file they were logged from
+# (all of bup logs to the same application logger)
 log_sources_by_filename = {
     "s3_backup.py": LogSources.s3,
     "aws_cli.py": LogSources.s3,
@@ -35,6 +43,9 @@ log_sources_by_filename = {
 
 
 def get_log_source(record: logging.LogRecord) -> LogSources:
+    backup_type = getattr(record, "backup_type", None)
+    if backup_type in log_sources_by_backup_type:
+        return log_sources_by_backup_type[backup_type]
     return log_sources_by_filename.get(record.filename, LogSources.application)
 
 

--- a/bup/gui/log_widget.py
+++ b/bup/gui/log_widget.py
@@ -1,8 +1,9 @@
 import logging
+from enum import Enum
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal, Qt
 from PyQt5.QtGui import QFontDatabase
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, QPushButton
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, QPushButton, QGroupBox, QSplitter
 from balsa import get_logger
 
 from bup import __application_name__
@@ -14,8 +15,28 @@ max_log_lines = 10000
 log_line_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(threadName)s %(message)s"
 
 
+class LogSources(Enum):
+    s3 = "AWS S3"
+    dynamodb = "DynamoDB"
+    github = "GitHub"
+    application = "Application"
+
+
+# records are routed to a pane by the source file they were logged from (all of bup logs to the same application logger)
+log_sources_by_filename = {
+    "s3_backup.py": LogSources.s3,
+    "aws_cli.py": LogSources.s3,
+    "dynamodb_backup.py": LogSources.dynamodb,
+    "github_backup.py": LogSources.github,
+}
+
+
+def get_log_source(record: logging.LogRecord) -> LogSources:
+    return log_sources_by_filename.get(record.filename, LogSources.application)
+
+
 class QtLogEmitter(QObject):
-    log_line_signal = pyqtSignal(str)
+    log_line_signal = pyqtSignal(str, str)  # (LogSources value, formatted log line)
 
 
 class QtLogHandler(logging.Handler):
@@ -30,12 +51,29 @@ class QtLogHandler(logging.Handler):
         self.setFormatter(logging.Formatter(log_line_format))
 
     def emit(self, record: logging.LogRecord):
-        self.emitter.log_line_signal.emit(self.format(record))
+        self.emitter.log_line_signal.emit(get_log_source(record).value, self.format(record))
+
+
+class LogPane(QGroupBox):
+    """
+    One log source's pane - a titled, read-only, monospaced, non-wrapping text view with FIFO line trimming.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.setLayout(QVBoxLayout())
+        self.text_box = QPlainTextEdit()
+        self.text_box.setReadOnly(True)
+        self.text_box.setMaximumBlockCount(max_log_lines)  # FIFO - drops the oldest lines
+        self.text_box.setLineWrapMode(QPlainTextEdit.NoWrap)
+        self.text_box.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
+        self.layout().addWidget(self.text_box)
 
 
 class LogWidget(QWidget):
     """
-    "Log" tab - detailed application log (e.g. the full AWS CLI command lines), fed by all log records of this application's logger
+    "Log" tab - detailed application log (e.g. the full AWS CLI command lines), fed by all log records of this application's logger,
+    with a separate pane per backup type plus one for the rest of the application.
     """
 
     def __init__(self):
@@ -48,21 +86,28 @@ class LogWidget(QWidget):
         self.clear_button = QPushButton("Clear")
         self.controls_layout.addWidget(self.clear_button)
         self.controls_layout.addStretch()
+        self.clear_button.clicked.connect(self.clear)
 
-        self.log_text_box = QPlainTextEdit()
-        self.log_text_box.setReadOnly(True)
-        self.log_text_box.setMaximumBlockCount(max_log_lines)  # FIFO - drops the oldest lines
-        self.log_text_box.setLineWrapMode(QPlainTextEdit.NoWrap)
-        self.log_text_box.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
-        self.clear_button.clicked.connect(self.log_text_box.clear)
+        self.splitter = QSplitter(Qt.Vertical)
+        self.log_panes = {}
+        for log_source in LogSources:
+            self.log_panes[log_source] = LogPane(log_source.value)
+            self.splitter.addWidget(self.log_panes[log_source])
 
         self.layout().addWidget(self.controls_widget)
-        self.layout().addWidget(self.log_text_box)
+        self.layout().addWidget(self.splitter)
 
         self.log_handler = QtLogHandler()
         self.log_handler.setLevel(logging.DEBUG)  # display everything the logger's own level lets through (e.g. DEBUG with the verbose preference)
-        self.log_handler.emitter.log_line_signal.connect(self.log_text_box.appendPlainText)
+        self.log_handler.emitter.log_line_signal.connect(self.append_log_line)
         logging.getLogger(__application_name__).addHandler(self.log_handler)
+
+    def append_log_line(self, log_source_value: str, line: str):
+        self.log_panes[LogSources(log_source_value)].text_box.appendPlainText(line)
+
+    def clear(self):
+        for log_pane in self.log_panes.values():
+            log_pane.text_box.clear()
 
     def detach(self):
         """

--- a/bup/gui/log_widget.py
+++ b/bup/gui/log_widget.py
@@ -7,10 +7,13 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPlainTextEdit, Q
 from balsa import get_logger
 
 from bup import __application_name__
+from bup.gui import get_gui_preferences
 
 log = get_logger(__application_name__)
 
 max_log_lines = 10000
+
+minimum_pane_height = 50  # pixels
 
 log_line_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(threadName)s %(message)s"
 
@@ -101,6 +104,27 @@ class LogWidget(QWidget):
         self.log_handler.setLevel(logging.DEBUG)  # display everything the logger's own level lets through (e.g. DEBUG with the verbose preference)
         self.log_handler.emitter.log_line_signal.connect(self.append_log_line)
         logging.getLogger(__application_name__).addHandler(self.log_handler)
+
+        self.restore_state()
+
+    def get_pane_height_key(self, log_source: LogSources) -> str:
+        return f"log_pane_{log_source.name}_height"
+
+    def save_state(self):
+        preferences = get_gui_preferences()
+        for log_source, pane_height in zip(LogSources, self.splitter.sizes()):
+            setattr(preferences, self.get_pane_height_key(log_source), pane_height)
+
+    def restore_state(self):
+        preferences = get_gui_preferences()
+        pane_heights = []
+        for log_source in LogSources:
+            pane_height = getattr(preferences, self.get_pane_height_key(log_source))
+            # make sure every pane comes up visible, even if not set or the user has collapsed it to zero
+            if pane_height is None or int(pane_height) < minimum_pane_height:
+                pane_height = minimum_pane_height
+            pane_heights.append(int(pane_height))
+        self.splitter.setSizes(pane_heights)
 
     def append_log_line(self, log_source_value: str, line: str):
         self.log_panes[LogSources(log_source_value)].text_box.appendPlainText(line)

--- a/bup/gui/preferences_widget.py
+++ b/bup/gui/preferences_widget.py
@@ -152,6 +152,11 @@ class PreferencesWidget(QWidget):
         self.dry_run_check_box.clicked.connect(self.dry_run_clicked)
         self.layout().addWidget(self.dry_run_check_box)
 
+        # S3 sync --size-only
+        self.s3_size_only_check_box = QCheckBox("S3 sync compares file size only, not timestamps (--size-only)")
+        self.s3_size_only_check_box.clicked.connect(self.s3_size_only_clicked)
+        self.layout().addWidget(self.s3_size_only_check_box)
+
         # verbose
         self.verbose_check_box = QCheckBox("Verbose")
         self.verbose_check_box.clicked.connect(self.verbose_clicked)
@@ -173,6 +178,7 @@ class PreferencesWidget(QWidget):
         if preferences.detailed_log_file_size_limit_mb is not None:
             self.detailed_log_file_size_limit.setValue(preferences.detailed_log_file_size_limit_mb)
         self.dry_run_check_box.setChecked(bool(preferences.dry_run))  # None translates to False
+        self.s3_size_only_check_box.setChecked(bool(preferences.s3_size_only))  # None translates to False
         self.verbose_check_box.setChecked(bool(preferences.verbose))  # None translates to False
         self.automatic_backup_enable_check_box.setChecked(bool(preferences.automatic_backup))
         if preferences.backup_period is not None:
@@ -238,6 +244,9 @@ class PreferencesWidget(QWidget):
 
     def dry_run_clicked(self):
         get_gui_preferences().dry_run = self.dry_run_check_box.isChecked()
+
+    def s3_size_only_clicked(self):
+        get_gui_preferences().s3_size_only = self.s3_size_only_check_box.isChecked()
 
     def automatic_backup_changed(self):
         preferences = get_gui_preferences()

--- a/bup/gui/preferences_widget.py
+++ b/bup/gui/preferences_widget.py
@@ -4,7 +4,7 @@ from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget, QPushButton, QLabel, QFileDialog, QLineEdit, QCheckBox, QSpinBox
 
 from bup import get_preferences, UITypes
-from bup.log_routing import set_detailed_file_logging
+from bup.log_routing import set_detailed_file_logging, default_file_size_limit_mb
 
 
 def get_gui_preferences():
@@ -135,6 +135,13 @@ class PreferencesWidget(QWidget):
         self.detailed_log_widget.layout().addWidget(QLabel("Detailed Log Directory (blank for none):"))
         self.detailed_log_widget.layout().addWidget(self.detailed_log_directory_line_edit)
         self.detailed_log_widget.layout().addWidget(self.select_detailed_log_directory_button)
+        self.detailed_log_widget.layout().addWidget(QLabel("File size limit (MB):"))
+        self.detailed_log_file_size_limit = QSpinBox()
+        self.detailed_log_file_size_limit.setMinimum(1)
+        self.detailed_log_file_size_limit.setMaximum(10000)
+        self.detailed_log_file_size_limit.setValue(default_file_size_limit_mb)
+        self.detailed_log_file_size_limit.valueChanged.connect(self.detailed_log_file_size_limit_changed)
+        self.detailed_log_widget.layout().addWidget(self.detailed_log_file_size_limit)
         self.detailed_log_widget.layout().addStretch()
         self.layout().addWidget(self.detailed_log_widget)
         self.layout().addWidget(QLabel())  # space
@@ -163,6 +170,8 @@ class PreferencesWidget(QWidget):
         self.aws_region_line_edit.setText(preferences.aws_region)
         self.github_token_line_edit.setText(preferences.github_token)
         self.detailed_log_directory_line_edit.setText(preferences.detailed_log_directory)
+        if preferences.detailed_log_file_size_limit_mb is not None:
+            self.detailed_log_file_size_limit.setValue(preferences.detailed_log_file_size_limit_mb)
         self.dry_run_check_box.setChecked(bool(preferences.dry_run))  # None translates to False
         self.verbose_check_box.setChecked(bool(preferences.verbose))  # None translates to False
         self.automatic_backup_enable_check_box.setChecked(bool(preferences.automatic_backup))
@@ -209,8 +218,12 @@ class PreferencesWidget(QWidget):
         get_gui_preferences().detailed_log_directory = self.detailed_log_directory_line_edit.text()
         self.detailed_log_apply_timer.start()
 
+    def detailed_log_file_size_limit_changed(self):
+        get_gui_preferences().detailed_log_file_size_limit_mb = self.detailed_log_file_size_limit.value()  # QSpinBox guarantees an int
+        self.detailed_log_apply_timer.start()
+
     def apply_detailed_log_directory(self):
-        set_detailed_file_logging(self.detailed_log_directory_line_edit.text())
+        set_detailed_file_logging(self.detailed_log_directory_line_edit.text(), self.detailed_log_file_size_limit.value())
 
     def github_visible_clicked(self):
         if self.github_token_line_edit.echoMode() == PreferencesLineEdit.Password:

--- a/bup/gui/preferences_widget.py
+++ b/bup/gui/preferences_widget.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget, QPushButton, QLabel, QFileDialog, QLineEdit, QCheckBox, QSpinBox
 
 from bup import get_preferences, UITypes
+from bup.log_routing import set_detailed_file_logging
 
 
 def get_gui_preferences():
@@ -118,6 +120,26 @@ class PreferencesWidget(QWidget):
         self.layout().addWidget(QLabel())  # space
         self.layout().addWidget(QLabel())  # space
 
+        # detailed log directory (optional - one log file per backup type, with e.g. the full AWS CLI calls and their output)
+        # debounce applying the directory so a half-typed path doesn't start collecting log files
+        self.detailed_log_apply_timer = QTimer(self)
+        self.detailed_log_apply_timer.setSingleShot(True)
+        self.detailed_log_apply_timer.setInterval(1000)  # ms
+        self.detailed_log_apply_timer.timeout.connect(self.apply_detailed_log_directory)
+        self.detailed_log_widget = QWidget()
+        self.detailed_log_widget.setLayout(QHBoxLayout())
+        self.detailed_log_directory_line_edit = PreferencesLineEdit()
+        self.detailed_log_directory_line_edit.textChanged.connect(self.detailed_log_directory_changed)
+        self.select_detailed_log_directory_button = QPushButton("Select Detailed Log Directory")
+        self.select_detailed_log_directory_button.clicked.connect(self.select_detailed_log_directory)
+        self.detailed_log_widget.layout().addWidget(QLabel("Detailed Log Directory (blank for none):"))
+        self.detailed_log_widget.layout().addWidget(self.detailed_log_directory_line_edit)
+        self.detailed_log_widget.layout().addWidget(self.select_detailed_log_directory_button)
+        self.detailed_log_widget.layout().addStretch()
+        self.layout().addWidget(self.detailed_log_widget)
+        self.layout().addWidget(QLabel())  # space
+        self.layout().addWidget(QLabel())  # space
+
         # dry run
         self.dry_run_check_box = QCheckBox("Dry run")
         self.dry_run_check_box.clicked.connect(self.dry_run_clicked)
@@ -140,6 +162,7 @@ class PreferencesWidget(QWidget):
         self.aws_secret_access_key_line_edit.setText(preferences.aws_secret_access_key)
         self.aws_region_line_edit.setText(preferences.aws_region)
         self.github_token_line_edit.setText(preferences.github_token)
+        self.detailed_log_directory_line_edit.setText(preferences.detailed_log_directory)
         self.dry_run_check_box.setChecked(bool(preferences.dry_run))  # None translates to False
         self.verbose_check_box.setChecked(bool(preferences.verbose))  # None translates to False
         self.automatic_backup_enable_check_box.setChecked(bool(preferences.automatic_backup))
@@ -176,6 +199,18 @@ class PreferencesWidget(QWidget):
 
     def github_token_changed(self):
         get_gui_preferences().github_token = self.github_token_line_edit.text()
+
+    def select_detailed_log_directory(self):
+        new_detailed_log_directory = QFileDialog.getExistingDirectory(self, "Select Detailed Log Directory")
+        if new_detailed_log_directory is not None and len(new_detailed_log_directory) > 0:
+            self.detailed_log_directory_line_edit.setText(new_detailed_log_directory)
+
+    def detailed_log_directory_changed(self):
+        get_gui_preferences().detailed_log_directory = self.detailed_log_directory_line_edit.text()
+        self.detailed_log_apply_timer.start()
+
+    def apply_detailed_log_directory(self):
+        set_detailed_file_logging(self.detailed_log_directory_line_edit.text())
 
     def github_visible_clicked(self):
         if self.github_token_line_edit.echoMode() == PreferencesLineEdit.Password:

--- a/bup/gui/run_backup_widget.py
+++ b/bup/gui/run_backup_widget.py
@@ -1,3 +1,4 @@
+import threading
 from enum import Enum
 from datetime import datetime
 
@@ -22,6 +23,7 @@ class RunAll(QThread):
         super().__init__()
 
     def run(self):
+        threading.current_thread().name = type(self).__name__  # QThreads otherwise show up in logs as "Dummy-N"
         for backup_type in self.widget.backup_engines:
             self.widget.backup_engines[backup_type].start()
         for backup_type in self.widget.backup_engines:

--- a/bup/log_routing.py
+++ b/bup/log_routing.py
@@ -39,20 +39,36 @@ def get_log_source(record: logging.LogRecord) -> LogSources:
     return log_sources_by_filename.get(record.filename, LogSources.application)
 
 
+bytes_per_mb = 1024 * 1024
+default_file_size_limit_mb = 10
+
+
 class DetailedFileLogHandler(logging.Handler):
     """
     Writes every log record to a file per log source in the given directory (s3.log, dynamodb.log, github.log, application.log),
     so each backup type's full details (e.g. the AWS CLI calls and their stdout/stderr) are captured separately.
+    When a file reaches max_bytes it is rotated to <name>.log.1 (replacing any previous rotation), so each source uses
+    at most about twice max_bytes of disk.
     """
 
-    def __init__(self, directory: Union[str, Path]):
+    def __init__(self, directory: Union[str, Path], max_bytes: int = default_file_size_limit_mb * bytes_per_mb):
         super().__init__()
         self.directory = Path(directory)
+        self.max_bytes = max_bytes
         self.setFormatter(logging.Formatter(log_line_format))
         self.files: Dict[LogSources, TextIO] = {}
 
     def get_log_file_path(self, log_source: LogSources) -> Path:
         return Path(self.directory, f"{log_source.name}.log")
+
+    def rotate(self, log_source: LogSources):
+        file = self.files.pop(log_source)
+        file.close()
+        log_file_path = self.get_log_file_path(log_source)
+        rotated_path = Path(f"{log_file_path}.1")
+        if rotated_path.exists():
+            rotated_path.unlink()
+        log_file_path.rename(rotated_path)
 
     def emit(self, record: logging.LogRecord):
         log_source = get_log_source(record)
@@ -65,6 +81,8 @@ class DetailedFileLogHandler(logging.Handler):
                 self.files[log_source] = file
             file.write(f"{self.format(record)}\n")
             file.flush()  # the point of this log is diagnosing problems - don't lose lines on a crash
+            if file.tell() >= self.max_bytes:
+                self.rotate(log_source)  # the next record reopens the (fresh) file lazily
         except OSError:
             self.handleError(record)
 
@@ -85,10 +103,11 @@ class DetailedFileLogHandler(logging.Handler):
 _detailed_file_log_handler: Optional[DetailedFileLogHandler] = None
 
 
-def set_detailed_file_logging(directory: Optional[Union[str, Path]]):
+def set_detailed_file_logging(directory: Optional[Union[str, Path]], file_size_limit_mb: Optional[int] = None):
     """
     Write detailed logs to the given directory (one file per log source), replacing any previous detailed log directory.
-    None (or blank) turns detailed file logging off.
+    None (or blank) turns detailed file logging off. file_size_limit_mb caps each log file's size (rotating to a single
+    .1 backup); None or a non-positive value uses the default.
     """
     global _detailed_file_log_handler
     logger = logging.getLogger(__application_name__)
@@ -98,6 +117,8 @@ def set_detailed_file_logging(directory: Optional[Union[str, Path]]):
         _detailed_file_log_handler = None
     directory_string = "" if directory is None else str(directory).strip()
     if len(directory_string) > 0:
-        _detailed_file_log_handler = DetailedFileLogHandler(Path(directory_string))
+        if file_size_limit_mb is None or file_size_limit_mb <= 0:
+            file_size_limit_mb = default_file_size_limit_mb
+        _detailed_file_log_handler = DetailedFileLogHandler(Path(directory_string), max_bytes=file_size_limit_mb * bytes_per_mb)
         _detailed_file_log_handler.setLevel(logging.DEBUG)  # capture everything the logger's own level lets through
         logger.addHandler(_detailed_file_log_handler)

--- a/bup/log_routing.py
+++ b/bup/log_routing.py
@@ -1,0 +1,103 @@
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Optional, TextIO, Union
+
+from bup import __application_name__, BackupTypes
+
+log_line_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(threadName)s %(message)s"
+
+
+class LogSources(Enum):
+    s3 = "AWS S3"
+    dynamodb = "DynamoDB"
+    github = "GitHub"
+    application = "Application"
+
+
+# records stamped with a backup type by BupBase (the info_out/warning_out/error_out path, whose records all originate in bup_base.py)
+log_sources_by_backup_type = {
+    BackupTypes.S3: LogSources.s3,
+    BackupTypes.DynamoDB: LogSources.dynamodb,
+    BackupTypes.github: LogSources.github,
+}
+
+# records logged directly (not via BupBase) are routed by the source file they were logged from
+# (all of bup logs to the same application logger)
+log_sources_by_filename = {
+    "s3_backup.py": LogSources.s3,
+    "aws_cli.py": LogSources.s3,
+    "dynamodb_backup.py": LogSources.dynamodb,
+    "github_backup.py": LogSources.github,
+}
+
+
+def get_log_source(record: logging.LogRecord) -> LogSources:
+    backup_type = getattr(record, "backup_type", None)
+    if backup_type in log_sources_by_backup_type:
+        return log_sources_by_backup_type[backup_type]
+    return log_sources_by_filename.get(record.filename, LogSources.application)
+
+
+class DetailedFileLogHandler(logging.Handler):
+    """
+    Writes every log record to a file per log source in the given directory (s3.log, dynamodb.log, github.log, application.log),
+    so each backup type's full details (e.g. the AWS CLI calls and their stdout/stderr) are captured separately.
+    """
+
+    def __init__(self, directory: Union[str, Path]):
+        super().__init__()
+        self.directory = Path(directory)
+        self.setFormatter(logging.Formatter(log_line_format))
+        self.files: Dict[LogSources, TextIO] = {}
+
+    def get_log_file_path(self, log_source: LogSources) -> Path:
+        return Path(self.directory, f"{log_source.name}.log")
+
+    def emit(self, record: logging.LogRecord):
+        log_source = get_log_source(record)
+        try:
+            file = self.files.get(log_source)
+            if file is None:
+                # open lazily so files and directories only appear once there is something to write
+                self.directory.mkdir(parents=True, exist_ok=True)
+                file = open(self.get_log_file_path(log_source), "a", encoding="utf-8")
+                self.files[log_source] = file
+            file.write(f"{self.format(record)}\n")
+            file.flush()  # the point of this log is diagnosing problems - don't lose lines on a crash
+        except OSError:
+            self.handleError(record)
+
+    def close(self):
+        self.acquire()
+        try:
+            for file in self.files.values():
+                try:
+                    file.close()
+                except OSError:
+                    pass  # closing on teardown - nothing useful to do about a failed close
+            self.files = {}
+        finally:
+            self.release()
+        super().close()
+
+
+_detailed_file_log_handler: Optional[DetailedFileLogHandler] = None
+
+
+def set_detailed_file_logging(directory: Optional[Union[str, Path]]):
+    """
+    Write detailed logs to the given directory (one file per log source), replacing any previous detailed log directory.
+    None (or blank) turns detailed file logging off.
+    """
+    global _detailed_file_log_handler
+    logger = logging.getLogger(__application_name__)
+    if _detailed_file_log_handler is not None:
+        logger.removeHandler(_detailed_file_log_handler)
+        _detailed_file_log_handler.close()
+        _detailed_file_log_handler = None
+    directory_string = "" if directory is None else str(directory).strip()
+    if len(directory_string) > 0:
+        _detailed_file_log_handler = DetailedFileLogHandler(Path(directory_string))
+        _detailed_file_log_handler.setLevel(logging.DEBUG)  # capture everything the logger's own level lets through
+        logger.addHandler(_detailed_file_log_handler)

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -25,6 +25,8 @@ class BupPreferences(Pref):
 
     dry_run: bool = attrib(default=False)
 
+    s3_size_only: bool = attrib(default=False)  # aws s3 sync --size-only (compare file size only, not timestamps)
+
     verbose: bool = attrib(default=False)
 
     detailed_log_directory: str = attrib(default=None)  # None/blank = detailed file logging off

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -27,6 +27,8 @@ class BupPreferences(Pref):
 
     verbose: bool = attrib(default=False)
 
+    detailed_log_directory: str = attrib(default=None)  # None/blank = detailed file logging off
+
     height: int = attrib(default=None)
     width: int = attrib(default=None)
     S3_exclusions_height: int = attrib(default=None)

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -28,6 +28,7 @@ class BupPreferences(Pref):
     verbose: bool = attrib(default=False)
 
     detailed_log_directory: str = attrib(default=None)  # None/blank = detailed file logging off
+    detailed_log_file_size_limit_mb: int = attrib(default=None)  # None = default limit
 
     height: int = attrib(default=None)
     width: int = attrib(default=None)

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -53,6 +53,10 @@ class BupPreferences(Pref):
     github_warnings_width: int = attrib(default=None)
     github_errors_height: int = attrib(default=None)
     github_errors_width: int = attrib(default=None)
+    log_pane_s3_height: int = attrib(default=None)
+    log_pane_dynamodb_height: int = attrib(default=None)
+    log_pane_github_height: int = attrib(default=None)
+    log_pane_application_height: int = attrib(default=None)
 
 
 def get_preferences(ui_type: UITypes) -> BupPreferences:

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -86,7 +86,7 @@ class S3Backup(BupBase):
                     break
         return process.returncode, stdout.decode(decoding, errors="replace"), stderr.decode(decoding, errors="replace")
 
-    def run(self):
+    def run_backup(self):
 
         preferences = get_preferences(self.ui_type)
         dry_run = preferences.dry_run

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -105,6 +105,7 @@ class S3Backup(BupBase):
 
         preferences = get_preferences(self.ui_type)
         dry_run = preferences.dry_run
+        size_only = preferences.s3_size_only
 
         backup_directory = os.path.join(preferences.backup_directory, "s3")
 
@@ -158,6 +159,8 @@ class S3Backup(BupBase):
             s3_bucket_path = f"s3://{bucket_name}"
             # Don't use --delete.  We want to keep 'old' files locally.
             sync_command_line = [str(aws_cli_path), "s3", "sync", s3_bucket_path, str(destination.absolute())]
+            if size_only:
+                sync_command_line.append("--size-only")
             if dry_run:
                 sync_command_line.append("--dryrun")
             log.info(subprocess.list2cmdline(sync_command_line))

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -50,6 +50,21 @@ def get_bucket_size(s3_client, bucket_name: str) -> Tuple[int, int]:
     return total_size, object_count
 
 
+def count_synced_files(sync_stdout: str) -> int:
+    """
+    Number of files "aws s3 sync" transferred (or would transfer, for a dry run), from its stdout -
+    the CLI emits one "download:" (or "copy:") line per file, and nothing for files already up to date.
+    """
+    synced_count = 0
+    for line in sync_stdout.splitlines():
+        line = line.strip()
+        if line.startswith("(dryrun) "):
+            line = line[len("(dryrun) ") :]
+        if line.startswith(("download:", "copy:")):
+            synced_count += 1
+    return synced_count
+
+
 def compare_backup_sizes(s3_total_size: int, local_size: int) -> Tuple[str, str]:
     """
     Rough check that the sync worked, based on total sizes.
@@ -122,6 +137,7 @@ class S3Backup(BupBase):
 
         count = 0
         dry_run_count = 0
+        total_synced_count = 0
         exclusions_no_comments = ExclusionPreferences(BackupTypes.S3.name).get_no_comments()
         for bucket_name in buckets:
             if self.stop_requested:
@@ -165,9 +181,13 @@ class S3Backup(BupBase):
                 self.error_out(f"aws s3 sync failed (exit code {sync_returncode}) for {bucket_name}")
                 continue  # don't count or verify a failed sync
 
+            synced_count = count_synced_files(sync_stdout)
+            total_synced_count += synced_count
+
             # check the results (skip during dry run - nothing was synced)
             if dry_run:
                 dry_run_count += 1
+                self.info_out(f"{bucket_name} : {synced_count} files would be synced")
                 continue
 
             try:
@@ -180,9 +200,11 @@ class S3Backup(BupBase):
             local_size, local_count = get_dir_size(destination)
             level, message = compare_backup_sizes(s3_total_size, local_size)
             output_routines = {"error": self.error_out, "info": log.info}
-            output_routines[level](f"{bucket_name} : {message} (s3_count={s3_object_count}, local_count={local_count}; s3_total_size={s3_total_size}, local_size={local_size})")
+            output_routines[level](
+                f"{bucket_name} : {message} (synced={synced_count}, s3_count={s3_object_count}, local_count={local_count}; s3_total_size={s3_total_size}, local_size={local_size})"
+            )
 
         if dry_run:
-            self.info_out(f"{len(buckets)} buckets, {dry_run_count} dry run, {len(exclusions_no_comments)} excluded")
+            self.info_out(f"{len(buckets)} buckets, {dry_run_count} dry run, {total_synced_count} files would be synced, {len(exclusions_no_comments)} excluded")
         else:
-            self.info_out(f"{len(buckets)} buckets, {count} backed up, {len(exclusions_no_comments)} excluded")
+            self.info_out(f"{len(buckets)} buckets, {count} backed up, {total_synced_count} files synced, {len(exclusions_no_comments)} excluded")

--- a/test_bup/test_bup_base.py
+++ b/test_bup/test_bup_base.py
@@ -1,9 +1,12 @@
+import threading
+
 from bup import BupBase, UITypes
 
 
 class _NoOpBackup(BupBase):
-    def run(self):
+    def run_backup(self):
         self.stop_requested_seen_in_run = self.stop_requested
+        self.thread_name_seen_in_run = threading.current_thread().name
 
 
 def _make_backup() -> _NoOpBackup:
@@ -34,6 +37,21 @@ def test_start_resets_error_count():
     assert backup.wait(10000)
 
     assert backup.error_count == 0
+
+
+def test_backup_thread_has_meaningful_name():
+    # QThreads aren't registered with Python's threading module, so without naming they'd log as "Dummy-N"
+    backup = _make_backup()
+    backup.start()
+    assert backup.wait(10000)
+    assert backup.thread_name_seen_in_run == "_NoOpBackup"
+
+
+def test_direct_run_does_not_rename_the_main_thread():
+    main_thread_name = threading.current_thread().name
+    backup = _make_backup()
+    backup.run()
+    assert threading.current_thread().name == main_thread_name
 
 
 def test_error_out_increments_error_count():

--- a/test_bup/test_bup_dialog.py
+++ b/test_bup/test_bup_dialog.py
@@ -52,6 +52,12 @@ def _make_fake_about_widget(parent=None):
     return QWidget(parent)
 
 
+def _make_fake_log_widget(parent=None):
+    w = QWidget(parent)
+    w.detach = MagicMock()
+    return w
+
+
 @pytest.fixture
 def mock_bup_dialog(qapp):
     mock_prefs = _make_mock_prefs()
@@ -62,6 +68,7 @@ def mock_bup_dialog(qapp):
         patch("bup.gui.bup_dialog.get_preferences", return_value=mock_prefs),
         patch("bup.gui.bup_dialog.RunBackupWidget", side_effect=_make_fake_run_backup_widget),
         patch("bup.gui.bup_dialog.PreferencesWidget", side_effect=_make_fake_preferences_widget),
+        patch("bup.gui.bup_dialog.LogWidget", side_effect=_make_fake_log_widget),
         patch("bup.gui.bup_dialog.BupAbout", side_effect=_make_fake_about_widget),
     ):
         mock_ctypes.windll = MagicMock()
@@ -73,7 +80,7 @@ def mock_bup_dialog(qapp):
 
 def test_creation(mock_bup_dialog):
     dialog, _ = mock_bup_dialog
-    assert dialog.tab_widget.count() == 3
+    assert dialog.tab_widget.count() == 4
     assert dialog.autobackup_timer is not None
 
 

--- a/test_bup/test_bup_dialog.py
+++ b/test_bup/test_bup_dialog.py
@@ -55,6 +55,7 @@ def _make_fake_about_widget(parent=None):
 def _make_fake_log_widget(parent=None):
     w = QWidget(parent)
     w.detach = MagicMock()
+    w.save_state = MagicMock()
     return w
 
 

--- a/test_bup/test_cli_main.py
+++ b/test_bup/test_cli_main.py
@@ -9,6 +9,7 @@ def _make_args(**overrides):
         token="ghp_token",
         profile="default",
         dry_run=False,
+        size_only=False,
         exclude=None,
         s3=False,
         dynamodb=False,
@@ -59,6 +60,23 @@ def test_dry_run_false_written_to_preferences(mock_get_prefs, mock_balsa, mock_g
     cli_main(_make_args(dry_run=False))
 
     assert prefs.dry_run is False
+
+
+@patch("bup.cli.cli_main.S3Backup")
+@patch("bup.cli.cli_main.DynamoDBBackup")
+@patch("bup.cli.cli_main.GithubBackup")
+@patch("bup.cli.cli_main.Balsa")
+@patch("bup.cli.cli_main.get_preferences")
+def test_size_only_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
+    prefs = _make_prefs()
+    mock_get_prefs.return_value = prefs
+    from bup.cli.cli_main import cli_main
+
+    cli_main(_make_args(size_only=True))
+    assert prefs.s3_size_only is True
+
+    cli_main(_make_args(size_only=False))
+    assert prefs.s3_size_only is False
 
 
 @patch("bup.cli.cli_main.S3Backup")

--- a/test_bup/test_cli_main.py
+++ b/test_bup/test_cli_main.py
@@ -26,13 +26,18 @@ def _make_engine(error_count: int = 0) -> MagicMock:
     return engine
 
 
+def _make_prefs() -> MagicMock:
+    # detailed file logging off - a bare MagicMock would look like a truthy directory and start writing log files
+    return MagicMock(detailed_log_directory=None, detailed_log_file_size_limit_mb=None)
+
+
 @patch("bup.cli.cli_main.S3Backup")
 @patch("bup.cli.cli_main.DynamoDBBackup")
 @patch("bup.cli.cli_main.GithubBackup")
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_dry_run_true_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     from bup.cli.cli_main import cli_main
 
@@ -47,7 +52,7 @@ def test_dry_run_true_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_dry_run_false_written_to_preferences(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     from bup.cli.cli_main import cli_main
 
@@ -62,7 +67,7 @@ def test_dry_run_false_written_to_preferences(mock_get_prefs, mock_balsa, mock_g
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_s3_backup_started_with_s3_flag(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     mock_engine = _make_engine()
     mock_s3.return_value = mock_engine
@@ -80,7 +85,7 @@ def test_s3_backup_started_with_s3_flag(mock_get_prefs, mock_balsa, mock_gh, moc
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_aws_flag_starts_both_s3_and_dynamodb(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     s3_engine = _make_engine()
     ddb_engine = _make_engine()
@@ -100,7 +105,7 @@ def test_aws_flag_starts_both_s3_and_dynamodb(mock_get_prefs, mock_balsa, mock_g
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_backup_errors_produce_nonzero_exit_code(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     mock_s3.return_value = _make_engine(error_count=2)
     from bup.cli.cli_main import cli_main
@@ -117,7 +122,7 @@ def test_backup_errors_produce_nonzero_exit_code(mock_get_prefs, mock_balsa, moc
 @patch("bup.cli.cli_main.Balsa")
 @patch("bup.cli.cli_main.get_preferences")
 def test_backup_without_errors_exits_normally(mock_get_prefs, mock_balsa, mock_gh, mock_ddb, mock_s3):
-    prefs = MagicMock()
+    prefs = _make_prefs()
     mock_get_prefs.return_value = prefs
     mock_s3.return_value = _make_engine(error_count=0)
     from bup.cli.cli_main import cli_main

--- a/test_bup/test_log_routing.py
+++ b/test_bup/test_log_routing.py
@@ -1,0 +1,94 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from bup import __application_name__, GithubBackup, UITypes
+from bup.log_routing import set_detailed_file_logging
+
+logger = logging.getLogger(__application_name__)
+
+
+@pytest.fixture
+def info_level_logger():
+    original_level = logger.level
+    logger.setLevel(logging.INFO)  # balsa isn't initialized in tests, so set the level the app would normally have
+    yield logger
+    logger.setLevel(original_level)
+    set_detailed_file_logging(None)  # never leave a file handler behind for other tests
+
+
+def _emit_record_from_file(file_name: str, message: str):
+    """
+    Send a log record through the application logger as if it came from the given source file.
+    """
+    pathname = str(Path("bup", file_name).absolute())
+    record = logger.makeRecord(logger.name, logging.INFO, pathname, 1, message, (), None)
+    logger.handle(record)
+
+
+def test_records_route_to_per_source_files(tmp_path, info_level_logger):
+    set_detailed_file_logging(tmp_path)
+    _emit_record_from_file("s3_backup.py", 'aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"')
+    _emit_record_from_file("s3_backup.py", "my-bucket:download: s3://my-bucket/a.txt to a.txt")
+    _emit_record_from_file("github_backup.py", 'git clone "owner/repo"')
+    logger.info("an application level line")
+
+    s3_text = Path(tmp_path, "s3.log").read_text(encoding="utf-8")
+    assert "aws s3 sync s3://my-bucket" in s3_text  # the AWS CLI call itself
+    assert "download: s3://my-bucket/a.txt" in s3_text  # its stdout
+    assert "git clone" not in s3_text
+    assert 'git clone "owner/repo"' in Path(tmp_path, "github.log").read_text(encoding="utf-8")
+    assert "an application level line" in Path(tmp_path, "application.log").read_text(encoding="utf-8")
+    assert not Path(tmp_path, "dynamodb.log").exists()  # files are created lazily - no records, no file
+
+
+def test_engine_messages_route_by_backup_type(tmp_path, info_level_logger):
+    set_detailed_file_logging(tmp_path)
+    backup = GithubBackup(UITypes.cli, lambda s: None, lambda s: None, lambda s: None)
+    backup.info_out('git pull "owner/repo" branch:"main"')
+    assert "git pull" in Path(tmp_path, "github.log").read_text(encoding="utf-8")
+    assert not Path(tmp_path, "application.log").exists()
+
+
+def test_off_by_default_and_turn_off(tmp_path, info_level_logger):
+    logger.info("before enabling")
+    assert not Path(tmp_path, "application.log").exists()
+
+    set_detailed_file_logging(tmp_path)
+    logger.info("while enabled")
+    set_detailed_file_logging(None)
+    logger.info("after disabling")
+
+    application_text = Path(tmp_path, "application.log").read_text(encoding="utf-8")
+    assert "while enabled" in application_text
+    assert "before enabling" not in application_text
+    assert "after disabling" not in application_text
+
+
+def test_blank_directory_means_off(tmp_path, info_level_logger):
+    set_detailed_file_logging("   ")
+    logger.info("blank directory line")
+    assert not Path(tmp_path, "application.log").exists()
+
+
+def test_changing_the_directory_moves_the_files(tmp_path, info_level_logger):
+    first_directory = Path(tmp_path, "first")
+    second_directory = Path(tmp_path, "second")
+    set_detailed_file_logging(first_directory)
+    logger.info("first directory line")
+    set_detailed_file_logging(second_directory)
+    logger.info("second directory line")
+
+    first_text = Path(first_directory, "application.log").read_text(encoding="utf-8")
+    second_text = Path(second_directory, "application.log").read_text(encoding="utf-8")
+    assert "first directory line" in first_text
+    assert "second directory line" not in first_text
+    assert "second directory line" in second_text
+
+
+def test_directory_is_created_if_missing(tmp_path, info_level_logger):
+    new_directory = Path(tmp_path, "does", "not", "exist", "yet")
+    set_detailed_file_logging(new_directory)
+    logger.info("into a new directory")
+    assert "into a new directory" in Path(new_directory, "application.log").read_text(encoding="utf-8")

--- a/test_bup/test_log_routing.py
+++ b/test_bup/test_log_routing.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from bup import __application_name__, GithubBackup, UITypes
-from bup.log_routing import set_detailed_file_logging
+from bup.log_routing import DetailedFileLogHandler, set_detailed_file_logging
 
 logger = logging.getLogger(__application_name__)
 
@@ -85,6 +85,48 @@ def test_changing_the_directory_moves_the_files(tmp_path, info_level_logger):
     assert "first directory line" in first_text
     assert "second directory line" not in first_text
     assert "second directory line" in second_text
+
+
+def test_file_size_limit_rotates(tmp_path, info_level_logger):
+    max_bytes = 300
+    handler = DetailedFileLogHandler(tmp_path, max_bytes=max_bytes)
+    logger.addHandler(handler)
+    try:
+        line_count = 50
+        for i in range(line_count):
+            logger.info(f"line {i:04d}")
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
+
+    log_path = Path(tmp_path, "application.log")
+    rotated_path = Path(tmp_path, "application.log.1")
+    assert rotated_path.exists()
+    # the current file is always under the limit (it rotates as soon as it reaches it) - it may not even
+    # exist if the very last line triggered a rotation
+    if log_path.exists():
+        assert log_path.stat().st_size < max_bytes
+    # older rotations are dropped, so total retained lines are far fewer than were written
+    retained = (log_path.read_text(encoding="utf-8") if log_path.exists() else "") + rotated_path.read_text(encoding="utf-8")
+    assert 0 < len(retained.splitlines()) < line_count
+    # the newest line is always retained
+    assert f"line {line_count - 1:04d}" in retained
+
+
+def test_file_size_limit_only_rotates_the_large_file(tmp_path, info_level_logger):
+    handler = DetailedFileLogHandler(tmp_path, max_bytes=300)
+    logger.addHandler(handler)
+    try:
+        for i in range(50):
+            logger.info(f"line {i:04d}")
+        _emit_record_from_file("github_backup.py", "just one small github line")
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
+
+    assert Path(tmp_path, "application.log.1").exists()
+    assert not Path(tmp_path, "github.log.1").exists()
+    assert "github line" in Path(tmp_path, "github.log").read_text(encoding="utf-8")
 
 
 def test_directory_is_created_if_missing(tmp_path, info_level_logger):

--- a/test_bup/test_log_widget.py
+++ b/test_bup/test_log_widget.py
@@ -1,17 +1,25 @@
 import logging
 import threading
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from bup import __application_name__
-from bup.gui.log_widget import LogWidget, LogSources
+from bup.gui.log_widget import LogWidget, LogSources, minimum_pane_height
 
 logger = logging.getLogger(__application_name__)
 
 
 @pytest.fixture
-def log_widget(qapp):
+def mock_gui_preferences():
+    preferences = MagicMock(**{f"log_pane_{log_source.name}_height": None for log_source in LogSources})
+    with patch("bup.gui.log_widget.get_gui_preferences", return_value=preferences):
+        yield preferences
+
+
+@pytest.fixture
+def log_widget(qapp, mock_gui_preferences):
     original_level = logger.level
     logger.setLevel(logging.INFO)  # balsa isn't initialized in tests, so set the level the GUI would normally have
     widget = LogWidget()
@@ -87,3 +95,33 @@ def test_detach_stops_capture(log_widget):
     logger.info("after detach")
     for log_source in LogSources:
         assert "after detach" not in _pane_text(log_widget, log_source)
+
+
+def test_save_state_writes_pane_heights(log_widget, mock_gui_preferences):
+    with patch.object(log_widget.splitter, "sizes", return_value=[110, 120, 130, 140]):
+        log_widget.save_state()
+    assert mock_gui_preferences.log_pane_s3_height == 110
+    assert mock_gui_preferences.log_pane_dynamodb_height == 120
+    assert mock_gui_preferences.log_pane_github_height == 130
+    assert mock_gui_preferences.log_pane_application_height == 140
+
+
+def test_restore_state_applies_saved_pane_heights(log_widget, mock_gui_preferences):
+    mock_gui_preferences.log_pane_s3_height = 150
+    mock_gui_preferences.log_pane_dynamodb_height = 60
+    mock_gui_preferences.log_pane_github_height = 250
+    mock_gui_preferences.log_pane_application_height = 90
+    with patch.object(log_widget.splitter, "setSizes") as mock_set_sizes:
+        log_widget.restore_state()
+    mock_set_sizes.assert_called_once_with([150, 60, 250, 90])
+
+
+def test_restore_state_makes_every_pane_visible(log_widget, mock_gui_preferences):
+    # unset or collapsed-to-zero panes come back at the minimum height so none are invisible
+    mock_gui_preferences.log_pane_s3_height = 0
+    mock_gui_preferences.log_pane_dynamodb_height = None
+    mock_gui_preferences.log_pane_github_height = 10
+    mock_gui_preferences.log_pane_application_height = 300
+    with patch.object(log_widget.splitter, "setSizes") as mock_set_sizes:
+        log_widget.restore_state()
+    mock_set_sizes.assert_called_once_with([minimum_pane_height, minimum_pane_height, minimum_pane_height, 300])

--- a/test_bup/test_log_widget.py
+++ b/test_bup/test_log_widget.py
@@ -66,6 +66,18 @@ def test_dynamodb_records_route_to_dynamodb_pane(log_widget):
     assert "exporting my-table" not in _pane_text(log_widget, LogSources.application)
 
 
+def test_backup_engine_messages_route_by_backup_type(log_widget):
+    # info_out/warning_out/error_out messages are logged from bup_base.py, so they can't be routed by source file -
+    # BupBase stamps each record with its backup type instead (e.g. the "git pull ..." lines from the GitHub backup)
+    from bup import GithubBackup, UITypes
+
+    backup = GithubBackup(UITypes.cli, lambda s: None, lambda s: None, lambda s: None)
+    backup.info_out('git pull "owner/repo" branch:"main"')
+    assert "git pull" in _pane_text(log_widget, LogSources.github)
+    assert "git pull" not in _pane_text(log_widget, LogSources.application)
+    assert "git pull" not in _pane_text(log_widget, LogSources.s3)
+
+
 def test_other_records_route_to_application_pane(log_widget):
     logger.info("backup directory not set")  # logged from this test file, which is not a backup module
     assert "backup directory not set" in _pane_text(log_widget, LogSources.application)

--- a/test_bup/test_log_widget.py
+++ b/test_bup/test_log_widget.py
@@ -1,10 +1,11 @@
 import logging
 import threading
+from pathlib import Path
 
 import pytest
 
 from bup import __application_name__
-from bup.gui.log_widget import LogWidget
+from bup.gui.log_widget import LogWidget, LogSources
 
 logger = logging.getLogger(__application_name__)
 
@@ -19,12 +20,49 @@ def log_widget(qapp):
     logger.setLevel(original_level)
 
 
-def test_log_record_is_displayed(log_widget):
-    logger.info('aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"')
-    text = log_widget.log_text_box.toPlainText()
-    assert 'aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"' in text
-    assert "INFO" in text
-    assert "test_log_widget.py" in text  # the format includes the originating file and line
+def _emit_record_from_file(file_name: str, message: str):
+    """
+    Send a log record through the application logger as if it came from the given source file.
+    """
+    pathname = str(Path("bup", file_name).absolute())
+    record = logger.makeRecord(logger.name, logging.INFO, pathname, 1, message, (), None)
+    logger.handle(record)
+
+
+def _pane_text(log_widget: LogWidget, log_source: LogSources) -> str:
+    return log_widget.log_panes[log_source].text_box.toPlainText()
+
+
+def test_s3_records_route_to_s3_pane(log_widget):
+    _emit_record_from_file("s3_backup.py", 'aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"')
+    _emit_record_from_file("aws_cli.py", "AWS CLI 1.46.0 is up to date (latest: 1.46.0)")
+    s3_text = _pane_text(log_widget, LogSources.s3)
+    assert "aws s3 sync s3://my-bucket" in s3_text
+    assert "AWS CLI 1.46.0 is up to date" in s3_text  # aws_cli.py records belong to the S3 pane too
+    assert "INFO" in s3_text
+    assert "s3_backup.py" in s3_text  # the format includes the originating file and line
+    assert "aws s3 sync" not in _pane_text(log_widget, LogSources.github)
+    assert "aws s3 sync" not in _pane_text(log_widget, LogSources.application)
+
+
+def test_github_records_route_to_github_pane(log_widget):
+    _emit_record_from_file("github_backup.py", "cloning my-repo")
+    assert "cloning my-repo" in _pane_text(log_widget, LogSources.github)
+    assert "cloning my-repo" not in _pane_text(log_widget, LogSources.s3)
+    assert "cloning my-repo" not in _pane_text(log_widget, LogSources.application)
+
+
+def test_dynamodb_records_route_to_dynamodb_pane(log_widget):
+    _emit_record_from_file("dynamodb_backup.py", "exporting my-table")
+    assert "exporting my-table" in _pane_text(log_widget, LogSources.dynamodb)
+    assert "exporting my-table" not in _pane_text(log_widget, LogSources.application)
+
+
+def test_other_records_route_to_application_pane(log_widget):
+    logger.info("backup directory not set")  # logged from this test file, which is not a backup module
+    assert "backup directory not set" in _pane_text(log_widget, LogSources.application)
+    assert "backup directory not set" not in _pane_text(log_widget, LogSources.s3)
+    assert "backup directory not set" not in _pane_text(log_widget, LogSources.github)
 
 
 def test_log_record_from_worker_thread_is_displayed(qapp, log_widget):
@@ -33,17 +71,19 @@ def test_log_record_from_worker_thread_is_displayed(qapp, log_widget):
     worker.start()
     worker.join()
     qapp.processEvents()
-    assert "from worker thread" in log_widget.log_text_box.toPlainText()
+    assert "from worker thread" in _pane_text(log_widget, LogSources.application)
 
 
-def test_clear_button(log_widget):
-    logger.info("some log line")
-    assert "some log line" in log_widget.log_text_box.toPlainText()
+def test_clear_button_clears_all_panes(log_widget):
+    _emit_record_from_file("s3_backup.py", "s3 line")
+    _emit_record_from_file("github_backup.py", "github line")
     log_widget.clear_button.click()
-    assert log_widget.log_text_box.toPlainText() == ""
+    for log_source in LogSources:
+        assert _pane_text(log_widget, log_source) == ""
 
 
 def test_detach_stops_capture(log_widget):
     log_widget.detach()
     logger.info("after detach")
-    assert "after detach" not in log_widget.log_text_box.toPlainText()
+    for log_source in LogSources:
+        assert "after detach" not in _pane_text(log_widget, log_source)

--- a/test_bup/test_log_widget.py
+++ b/test_bup/test_log_widget.py
@@ -1,0 +1,49 @@
+import logging
+import threading
+
+import pytest
+
+from bup import __application_name__
+from bup.gui.log_widget import LogWidget
+
+logger = logging.getLogger(__application_name__)
+
+
+@pytest.fixture
+def log_widget(qapp):
+    original_level = logger.level
+    logger.setLevel(logging.INFO)  # balsa isn't initialized in tests, so set the level the GUI would normally have
+    widget = LogWidget()
+    yield widget
+    widget.detach()
+    logger.setLevel(original_level)
+
+
+def test_log_record_is_displayed(log_widget):
+    logger.info('aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"')
+    text = log_widget.log_text_box.toPlainText()
+    assert 'aws s3 sync s3://my-bucket "C:\\backup\\s3\\my-bucket"' in text
+    assert "INFO" in text
+    assert "test_log_widget.py" in text  # the format includes the originating file and line
+
+
+def test_log_record_from_worker_thread_is_displayed(qapp, log_widget):
+    # backups log from worker QThreads - the record crosses to the GUI thread via a queued signal, delivered by the event loop
+    worker = threading.Thread(target=lambda: logger.info("from worker thread"), name="worker")
+    worker.start()
+    worker.join()
+    qapp.processEvents()
+    assert "from worker thread" in log_widget.log_text_box.toPlainText()
+
+
+def test_clear_button(log_widget):
+    logger.info("some log line")
+    assert "some log line" in log_widget.log_text_box.toPlainText()
+    log_widget.clear_button.click()
+    assert log_widget.log_text_box.toPlainText() == ""
+
+
+def test_detach_stops_capture(log_widget):
+    log_widget.detach()
+    logger.info("after detach")
+    assert "after detach" not in log_widget.log_text_box.toPlainText()

--- a/test_bup/test_preferences_widget.py
+++ b/test_bup/test_preferences_widget.py
@@ -17,6 +17,7 @@ def _make_mock_prefs(**overrides):
         detailed_log_file_size_limit_mb=None,
         verbose=False,
         dry_run=False,
+        s3_size_only=False,
         automatic_backup=False,
         backup_period=None,
     )
@@ -91,6 +92,16 @@ def test_checkbox_verbose_dry_run(mock_get, qapp):
     w.dry_run_check_box.setChecked(True)
     w.dry_run_check_box.click()
     assert prefs.dry_run == w.dry_run_check_box.isChecked()
+    w.s3_size_only_check_box.click()
+    assert prefs.s3_size_only == w.s3_size_only_check_box.isChecked()
+
+
+@patch("bup.gui.preferences_widget.set_detailed_file_logging")
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_s3_size_only_loaded_true(mock_get, mock_set_detailed, qapp):
+    mock_get.return_value = _make_mock_prefs(s3_size_only=True)
+    w = PreferencesWidget()
+    assert w.s3_size_only_check_box.isChecked()
 
 
 @patch("bup.gui.preferences_widget.get_gui_preferences")

--- a/test_bup/test_preferences_widget.py
+++ b/test_bup/test_preferences_widget.py
@@ -14,6 +14,7 @@ def _make_mock_prefs(**overrides):
         aws_region="us-east-1",
         github_token="ghp_token",
         detailed_log_directory=None,
+        detailed_log_file_size_limit_mb=None,
         verbose=False,
         dry_run=False,
         automatic_backup=False,
@@ -132,7 +133,28 @@ def test_detailed_log_directory_changed(mock_get, mock_set_detailed, qapp, tmp_p
     mock_set_detailed.assert_not_called()
     w.detailed_log_apply_timer.stop()
     w.apply_detailed_log_directory()
-    mock_set_detailed.assert_called_once_with(str(tmp_path))
+    mock_set_detailed.assert_called_once_with(str(tmp_path), w.detailed_log_file_size_limit.value())
+
+
+@patch("bup.gui.preferences_widget.set_detailed_file_logging")
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_detailed_log_file_size_limit_changed(mock_get, mock_set_detailed, qapp):
+    prefs = _make_mock_prefs()
+    mock_get.return_value = prefs
+    w = PreferencesWidget()
+    w.detailed_log_file_size_limit.setValue(25)
+    assert prefs.detailed_log_file_size_limit_mb == 25
+    assert w.detailed_log_apply_timer.isActive()
+    w.detailed_log_apply_timer.stop()
+
+
+@patch("bup.gui.preferences_widget.set_detailed_file_logging")
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_detailed_log_file_size_limit_loaded(mock_get, mock_set_detailed, qapp):
+    mock_get.return_value = _make_mock_prefs(detailed_log_file_size_limit_mb=42)
+    w = PreferencesWidget()
+    assert w.detailed_log_file_size_limit.value() == 42
+    w.detailed_log_apply_timer.stop()
 
 
 @patch("bup.gui.preferences_widget.get_gui_preferences")

--- a/test_bup/test_preferences_widget.py
+++ b/test_bup/test_preferences_widget.py
@@ -13,6 +13,7 @@ def _make_mock_prefs(**overrides):
         aws_secret_access_key="SECRET",
         aws_region="us-east-1",
         github_token="ghp_token",
+        detailed_log_directory=None,
         verbose=False,
         dry_run=False,
         automatic_backup=False,
@@ -116,6 +117,22 @@ def test_dry_run_loaded_false(mock_get, qapp):
     mock_get.return_value = _make_mock_prefs(dry_run=False)
     w = PreferencesWidget()
     assert not w.dry_run_check_box.isChecked()
+
+
+@patch("bup.gui.preferences_widget.set_detailed_file_logging")
+@patch("bup.gui.preferences_widget.get_gui_preferences")
+def test_detailed_log_directory_changed(mock_get, mock_set_detailed, qapp, tmp_path):
+    prefs = _make_mock_prefs()
+    mock_get.return_value = prefs
+    w = PreferencesWidget()
+    w.detailed_log_directory_line_edit.setText(str(tmp_path))
+    assert prefs.detailed_log_directory == str(tmp_path)
+    # applying the directory is debounced so a half-typed path doesn't start collecting log files
+    assert w.detailed_log_apply_timer.isActive()
+    mock_set_detailed.assert_not_called()
+    w.detailed_log_apply_timer.stop()
+    w.apply_detailed_log_directory()
+    mock_set_detailed.assert_called_once_with(str(tmp_path))
 
 
 @patch("bup.gui.preferences_widget.get_gui_preferences")

--- a/test_bup/test_s3_backup.py
+++ b/test_bup/test_s3_backup.py
@@ -6,7 +6,7 @@ import pytest
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from bup import UITypes
-from bup.s3_backup import S3Backup, compare_backup_sizes, get_bucket_size, get_dir_size
+from bup.s3_backup import S3Backup, compare_backup_sizes, count_synced_files, get_bucket_size, get_dir_size
 
 fake_aws_cli = (Path("aws"), Path("python"))
 
@@ -50,6 +50,20 @@ def _make_preferences(tmp_path: Path, dry_run: bool = False) -> MagicMock:
     preferences.aws_secret_access_key = None
     preferences.aws_region = None
     return preferences
+
+
+def test_count_synced_files():
+    sync_stdout = "download: s3://b/k1.txt to dir\\k1.txt\nCompleted 2 of 3 file(s)\ndownload: s3://b/k2.txt to dir\\k2.txt\ncopy: s3://b/k3.txt to s3://b/k3-copy.txt\n"
+    assert count_synced_files(sync_stdout) == 3
+
+
+def test_count_synced_files_dry_run():
+    assert count_synced_files("(dryrun) download: s3://b/k.txt to dir\\k.txt\n") == 1
+
+
+def test_count_synced_files_nothing_to_do():
+    # files already up to date produce no output
+    assert count_synced_files("") == 0
 
 
 def test_compare_backup_sizes_missing_files_is_error():
@@ -195,6 +209,44 @@ def test_outdated_aws_cli_surfaces_warning(mock_get_prefs, mock_s3_access, mock_
         backup.run()
 
     assert any("not the latest" in w for w in warnings)
+
+
+@patch("bup.s3_backup.get_bucket_size")
+@patch("bup.s3_backup.find_aws_cli", return_value=fake_aws_cli)
+@patch("bup.s3_backup.ExclusionPreferences")
+@patch("bup.s3_backup.S3Access")
+@patch("bup.s3_backup.get_preferences")
+def test_synced_file_count_in_summary(mock_get_prefs, mock_s3_access, mock_exclusions, mock_find_aws_cli, mock_get_bucket_size, tmp_path):
+    mock_get_prefs.return_value = _make_preferences(tmp_path)
+    mock_s3_access.return_value.bucket_list.return_value = ["my-bucket"]
+    mock_exclusions.return_value.get_no_comments.return_value = []
+    mock_get_bucket_size.return_value = (0, 0)
+    infos = []
+    backup = _make_backup(info=infos.append)
+
+    sync_stdout = "download: s3://my-bucket/a.txt to dir\\a.txt\ndownload: s3://my-bucket/b.txt to dir\\b.txt\n"
+    with patch.object(S3Backup, "run_stoppable_subprocess", return_value=(0, sync_stdout, "")):
+        backup.run()
+
+    assert any("2 files synced" in i for i in infos)
+
+
+@patch("bup.s3_backup.find_aws_cli", return_value=fake_aws_cli)
+@patch("bup.s3_backup.ExclusionPreferences")
+@patch("bup.s3_backup.S3Access")
+@patch("bup.s3_backup.get_preferences")
+def test_synced_file_count_in_dry_run_summary(mock_get_prefs, mock_s3_access, mock_exclusions, mock_find_aws_cli, tmp_path):
+    mock_get_prefs.return_value = _make_preferences(tmp_path, dry_run=True)
+    mock_s3_access.return_value.bucket_list.return_value = ["my-bucket"]
+    mock_exclusions.return_value.get_no_comments.return_value = []
+    infos = []
+    backup = _make_backup(info=infos.append)
+
+    sync_stdout = "(dryrun) download: s3://my-bucket/a.txt to dir\\a.txt\n"
+    with patch.object(S3Backup, "run_stoppable_subprocess", return_value=(0, sync_stdout, "")):
+        backup.run()
+
+    assert any("1 files would be synced" in i for i in infos)
 
 
 @patch("bup.s3_backup.get_bucket_size")

--- a/test_bup/test_s3_backup.py
+++ b/test_bup/test_s3_backup.py
@@ -41,10 +41,11 @@ def _make_backup(info=None, warning=None, error=None) -> S3Backup:
     return S3Backup(UITypes.cli, info or (lambda s: None), warning or (lambda s: None), error or (lambda s: None))
 
 
-def _make_preferences(tmp_path: Path, dry_run: bool = False) -> MagicMock:
+def _make_preferences(tmp_path: Path, dry_run: bool = False, s3_size_only: bool = False) -> MagicMock:
     preferences = MagicMock()
     preferences.backup_directory = str(tmp_path)
     preferences.dry_run = dry_run
+    preferences.s3_size_only = s3_size_only
     preferences.aws_profile = None
     preferences.aws_access_key_id = None
     preferences.aws_secret_access_key = None
@@ -151,6 +152,24 @@ def test_excluded_bucket_is_not_synced(mock_get_prefs, mock_s3_access, mock_excl
     sync_command_line = mock_subprocess.call_args.args[0]
     assert any("backed-up-bucket" in part for part in sync_command_line)
     assert "--dryrun" in sync_command_line
+    assert "--size-only" not in sync_command_line  # off by default
+
+
+@patch("bup.s3_backup.find_aws_cli", return_value=fake_aws_cli)
+@patch("bup.s3_backup.ExclusionPreferences")
+@patch("bup.s3_backup.S3Access")
+@patch("bup.s3_backup.get_preferences")
+def test_size_only_preference_adds_the_flag(mock_get_prefs, mock_s3_access, mock_exclusions, mock_find_aws_cli, tmp_path):
+    mock_get_prefs.return_value = _make_preferences(tmp_path, dry_run=True, s3_size_only=True)
+    mock_s3_access.return_value.bucket_list.return_value = ["my-bucket"]
+    mock_exclusions.return_value.get_no_comments.return_value = []
+    backup = _make_backup()
+
+    with patch.object(S3Backup, "run_stoppable_subprocess", return_value=(0, "", "")) as mock_subprocess:
+        backup.run()
+
+    sync_command_line = mock_subprocess.call_args.args[0]
+    assert "--size-only" in sync_command_line
 
 
 @patch("bup.s3_backup.get_bucket_size")


### PR DESCRIPTION
## Summary### Log tab- New `bup/gui/log_widget.py` with a `LogWidget` tab showing the detailed application log - every record that flows through the balsa/`bup` logger, including the full `aws s3 sync` command lines and their stdout/stderr.- Separate resizable panes (vertical splitter): **AWS S3**, **DynamoDB**, **GitHub**, and **Application**. Pane heights are saved to preferences on close and restored on startup (unset/collapsed panes come back at a minimum height).- Records are routed to panes by the backup type `BupBase` stamps on each `info_out`/`warning_out`/`error_out` record (those all originate in `bup_base.py`, so source-file routing alone would misfile them), falling back to the source file for direct log calls. Routing lives in the Qt-free `bup/log_routing.py`.- Backup threads now have meaningful names in log lines (`S3Backup`, `DynamoDBBackup`, `GithubBackup`, `RunAll`) instead of `Dummy-N`: `BupBase.run()` is a template method that names the QThread and calls the new `run_backup()` the engines implement.- Capture is via a `logging.Handler` forwarding formatted records to the GUI thread through a Qt signal. Monospaced non-wrapping views, 10,000-line FIFO cap each, Clear button clears all panes, and the handler detaches on close.### Detailed logs saved to files- New **Detailed Log Directory** preference (Preferences tab, with a directory picker; blank = off). When set, `DetailedFileLogHandler` writes every log record to one file per source in that directory: `s3.log`, `dynamodb.log`, `github.log`, `application.log` - so each AWS CLI call and its stdout/stderr are captured per backup type.- **File size limit**: a "File size limit (MB)" preference (default 10 MB) caps each log file; on reaching the limit the file rotates to `<name>.log.1` (replacing the previous rotation), bounding disk use to about twice the limit per source.- Applies live when either preference changes (debounced 1s so a half-typed path does not start collecting files); both GUI and CLI attach the handler at startup when set. Files are created lazily and flushed per line so a crash loses nothing.### Synced file count- The S3 backup counts the files `aws s3 sync` actually transferred (the CLI emits one `download:`/`copy:` line per file; up-to-date files emit nothing) and reports it per bucket (`synced=N` in the verification line), in dry runs (`N files would be synced`), and in the run summary (`... 87 files synced ...`).### S3 sync --size-only preference
- New `s3_size_only` preference, **default off**. When enabled, `aws s3 sync` runs with `--size-only` (files compared by size only, not timestamps). GUI: checkbox in the Preferences tab; CLI: `--size_only` flag, written to preferences like `--dry_run`.

## Testing- `test_log_routing.py`: per-source file routing (including engine-stamped records), off-by-default/turn-off/blank-directory, directory switching, lazy file/directory creation, and size-limit rotation (oldest lines dropped, newest always retained, only the oversized file rotates).- `test_log_widget.py`: pane routing, worker-thread delivery, Clear, detach, pane-size save/restore.- `test_s3_backup.py`: `count_synced_files` units plus run-level summary assertions (real and dry run).- `test_bup_base.py`: thread naming and the main-thread guard. `test_preferences_widget.py`: directory and size-limit preferences with debounce. `test_cli_main.py`: preference mocks modeled properly.- All 118 tests pass; flake8 clean.🤖 Generated with [Claude Code](https://claude.com/claude-code)