### PR TITLE
Fix pypi.bat: never upload a stale wheel

### DIFF
--- a/pypi.bat
+++ b/pypi.bat
@@ -1,22 +1,39 @@
 setlocal
 
-call build.bat
-
-if not exist dist\*.whl (
-    echo ERROR: build failed - no wheel found in dist
+REM use %~dp0 so the sibling scripts are found no matter how this script is invoked
+REM (a bare "call build.bat" can fail to resolve in some shells, and the stale
+REM contents of dist would then get uploaded)
+call "%~dp0build.bat"
+if errorlevel 1 (
+    echo ERROR: build.bat failed - not uploading
     exit /b 1
 )
 
-call venv\Scripts\activate.bat
+REM determine the current version so a stale wheel in dist can't satisfy the check below
+set version=
+for /f "tokens=2 delims==" %%v in ('findstr /b /c:"__version__" "%~dp0bup\__version__.py"') do set version=%%v
+set version=%version: =%
+set version=%version:"=%
+if "%version%"=="" (
+    echo ERROR: could not determine the version from bup\__version__.py - not uploading
+    exit /b 1
+)
 
-twine check --strict dist/*
+if not exist "%~dp0dist\bup-%version%-*.whl" (
+    echo ERROR: build failed - no bup-%version% wheel found in dist
+    exit /b 1
+)
+
+call "%~dp0venv\Scripts\activate.bat"
+
+twine check --strict "%~dp0dist/*"
 if errorlevel 1 (
     echo ERROR: twine check failed - not uploading
     call deactivate
     exit /b 1
 )
 
-twine upload dist/*
+twine upload "%~dp0dist/*"
 if errorlevel 1 (
     echo ERROR: twine upload failed
     call deactivate


### PR DESCRIPTION
## Summary
During the 0.13.0 release, `call build.bat` failed to resolve (bare batch names do not resolve from the working directory in some shells), `pypi.bat` continued anyway, and its "no wheel found" guard was satisfied by a stale 0.12.0 wheel left in `dist` - so it attempted to upload the previous release. PyPI rejected the duplicate, but an unreleased stale wheel would have shipped.

- Call `build.bat` and `activate.bat` via `%~dp0` so sibling scripts always resolve regardless of how the script is invoked, and abort if the call errors.
- Parse the current version from `bup\__version__.py` (findstr, no python needed) and require `dist\bup-<version>-*.whl` specifically, so stale artifacts can never satisfy the guard. Abort if the version cannot be parsed.
- `twine check`/`upload` also use `%~dp0`-anchored paths.

## Verification
- Version parsing tested against the real `__version__.py` (yields `0.13.0`, and the empty-version guard behaves).
- Guard tested positive (current 0.13.0 wheel found) and negative (0.12.0 pattern correctly absent).
- `twine check --strict` confirmed to expand the quoted `%~dp0dist/*` wildcard (both wheel and sdist checked, PASSED).
- A successful `build.bat` leaves errorlevel 0, so the new fail-fast cannot false-trip on a good build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
