### PR TITLE
Bump version to 0.13.1; venv on Python 3.14; pyship ui key

### DIFF
--- a/bup/__version__.py
+++ b/bup/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __application_name__ = "bup"
 __title__ = __application_name__
 __author__ = "abel"

--- a/make_venv.bat
+++ b/make_venv.bat
@@ -1,6 +1,6 @@
 mkdir temp
 rmdir /S /Q venv
-"C:\Program Files\Python313\python.exe" -m venv --clear venv
+"C:\Program Files\Python314\python.exe" -m venv --clear venv
 venv\Scripts\python -m pip install --upgrade pip
 venv\Scripts\python -m pip install -U setuptools
 venv\Scripts\python -m pip install -U -e .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ include = ["bup*"]
 bup = ["bup.png", "bup.ico", "LICENSE", "gpl-3.0.md"]
 
 [tool.pyship]
-is_gui = true
+ui = "gui"
 upload = true
 public_readable = true
 


### PR DESCRIPTION
Release prep for 0.13.1:
- Bump version to 0.13.1
- make_venv.bat: create the venv with Python 3.14
- pyproject.toml: pyship config key `is_gui = true` -> `ui = "gui"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)