### PR TITLE
Suppress console window flash when spawning the AWS CLI on Windows

### DIFF
--- a/bup/aws_cli.py
+++ b/bup/aws_cli.py
@@ -16,6 +16,9 @@ log = get_logger(__application_name__)
 
 decoding = "utf-8"
 
+# on Windows, a console-less parent (e.g. the GUI app) spawning the AWS CLI would otherwise pop up a new console window
+subprocess_creation_flags = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+
 awscli_pypi_url = "https://pypi.org/pypi/awscli/json"
 
 
@@ -64,7 +67,7 @@ def get_aws_cli_version(aws_cli_path: Path, env_var: dict) -> Optional[str]:
     """
     command_line = [str(aws_cli_path), "--version"]
     try:
-        result = subprocess.run(command_line, env=env_var, capture_output=True, timeout=60.0)
+        result = subprocess.run(command_line, env=env_var, capture_output=True, timeout=60.0, creationflags=subprocess_creation_flags)
     except (OSError, subprocess.SubprocessError) as e:
         log.warning(f'error executing {" ".join(command_line)} : {e}')
         return None

--- a/bup/s3_backup.py
+++ b/bup/s3_backup.py
@@ -12,7 +12,7 @@ logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
 from bup import __application_name__, BupBase, BackupTypes, get_preferences, ExclusionPreferences
-from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version, get_latest_awscli_version, check_aws_cli_version
+from bup.aws_cli import find_aws_cli, make_aws_cli_env, get_aws_cli_version, get_latest_awscli_version, check_aws_cli_version, subprocess_creation_flags
 
 log = get_logger(__application_name__)
 
@@ -89,7 +89,7 @@ class S3Backup(BupBase):
         Run a subprocess, polling for a stop request. On stop, terminate the subprocess so it isn't orphaned.
         :return: (returncode, stdout, stderr)
         """
-        process = subprocess.Popen(command_line, env=env_var, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(command_line, env=env_var, stdout=subprocess.PIPE, stderr=subprocess.PIPE, creationflags=subprocess_creation_flags)
         while True:
             try:
                 stdout, stderr = process.communicate(timeout=1.0)


### PR DESCRIPTION
## Summary
- On Windows, when bup runs as a GUI app (no console of its own, e.g. the pyship-installed app), each AWS CLI subprocess got a brand-new console window that popped up and vanished during backup.
- Add a `subprocess_creation_flags` constant in `aws_cli.py` (`CREATE_NO_WINDOW` on Windows, 0 elsewhere) and pass it to both AWS CLI spawn sites: the `aws s3 sync` `Popen` in `S3Backup.run_stoppable_subprocess` and the `aws --version` check in `get_aws_cli_version`.
- stdout/stderr were already captured via pipes, so hiding the console loses no output.

## Testing
- `pytest`: 121 passed
- `flake8` (project ignore list): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)