### PR TITLE
Bump version to 0.13.2

### DIFF
--- a/bup/__version__.py
+++ b/bup/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 __application_name__ = "bup"
 __title__ = __application_name__
 __author__ = "abel"


### PR DESCRIPTION
Version bump for the 0.13.2 release, which includes the CREATE_NO_WINDOW fix (#36) suppressing the console window flash when spawning the AWS CLI from the GUI app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)