### PR TITLE
Strip whitespace from exclusion entries so padded names still match

### DIFF
--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -73,5 +73,10 @@ class ExclusionPreferences(PrefOrderedSet):
         super().__init__(__application_name__, __author__, f"exclusions_{exclusion_type}")
 
     def get_no_comments(self) -> List[str]:
-        # get list of exclusions with comment and blank lines removed (tolerating leading whitespace)
-        return [s for s in super().get() if len(s.strip()) > 0 and not s.strip().startswith("#")]
+        """
+        Exclusion entries with rudimentary sanitization applied: comment lines (first non-whitespace character is "#")
+        and blank/whitespace-only lines are dropped, and leading/trailing whitespace is stripped from the remaining entries
+        so that e.g. "my-bucket " still matches "my-bucket".
+        """
+        stripped_entries = [s.strip() for s in super().get()]
+        return [s for s in stripped_entries if len(s) > 0 and not s.startswith("#")]

--- a/test_bup/test_preferences.py
+++ b/test_bup/test_preferences.py
@@ -27,3 +27,23 @@ def test_preferences():
 
     # restore
     exclusions.set(saved_exclusions)
+
+
+def test_exclusions_sanitization():
+    exclusions = ExclusionPreferences(BackupTypes.S3.name)
+    saved_exclusions = exclusions.get()
+    test_list = [
+        "# a comment",
+        "   # an indented comment",
+        "",
+        "   ",
+        "	",
+        "bucket-a",
+        "  bucket-b  ",  # leading/trailing whitespace is stripped
+        "bucket-c	",
+    ]
+    exclusions.set(test_list)
+    assert exclusions.get_no_comments() == ["bucket-a", "bucket-b", "bucket-c"]
+
+    # restore
+    exclusions.set(saved_exclusions)


### PR DESCRIPTION
## Summary
- `ExclusionPreferences.get_no_comments()` already dropped `#` comment lines and blank/whitespace-only lines, but returned surviving entries **unstripped**, so an entry like `"my-bucket "` (trailing space/tab) would never match a bucket, table, or repo name.
- Entries are now stripped of leading/trailing whitespace before being returned.
- New `test_exclusions_sanitization` covers comments (including indented), empty/whitespace-only/tab-only lines, and padded entries.

## Test plan
- [x] `pytest test_bup` — 124 passed locally
- [x] flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eEW1r522zUKgHWkFNWRAf