### PR TITLE
Support inline trailing comments in exclusion lists and document the syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python -m bup <path> -s    # CLI with S3 backup
 - `DynamoDBBackup` - Uses awsimple, exports tables to pickle and JSON
 - `GithubBackup` - Uses github3.py for API access, GitPython for git operations (clone/pull all branches)
 
-**Preferences:** SQLite-backed via the `pref` library with `attrs` data classes. CLI and GUI have separate preference stores. Exclusion lists (per backup type) support comment lines starting with `#`.
+**Preferences:** SQLite-backed via the `pref` library with `attrs` data classes. CLI and GUI have separate preference stores. Exclusion lists (per backup type) are sanitized by `ExclusionPreferences.get_no_comments()`: `#` starts a comment (whole-line or inline trailing), blank lines are dropped, and entries are whitespace-stripped (see README "Exclusions").
 
 **GUI:** PyQt5 tabbed dialog (`BupDialog`) with `RunBackupWidget`, `PreferencesWidget`, `LogWidget` (detailed application log via a logging handler), and `BupAbout` tabs.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 backup for github repos and AWS S3 and DynamoDB
 
+# Exclusions
+
+Each backup type (S3, DynamoDB, GitHub) has an exclusion list: names to skip, one per line. S3 entries are bucket
+names, DynamoDB entries are table names, and GitHub entries are either a repo name (`my-repo`) or `owner/my-repo`.
+Exclusion lists are edited in the GUI's "Exclusions" box for each backup type.
+
+The list syntax is deliberately simple:
+
+- `#` starts a comment that runs to the end of the line. This works for whole-line comments and for inline
+  trailing comments, e.g. `my-bucket  # too big, backed up elsewhere`.
+- Blank and whitespace-only lines are ignored.
+- Leading and trailing whitespace around a name is ignored, so `  my-bucket ` matches `my-bucket`.
+- Names are matched exactly (no wildcards).
+
+```
+# S3 buckets to skip
+logs-archive        # 2 TB, backed up by a lifecycle rule instead
+scratch-bucket
+```
+
 # Security Notes
 
 - Credentials you enter (AWS secret access key, GitHub token) are stored **unencrypted** in a local

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each backup type (S3, DynamoDB, GitHub) has an exclusion list: names to skip, on
 names, DynamoDB entries are table names, and GitHub entries are either a repo name (`my-repo`) or `owner/my-repo`.
 Exclusion lists are edited in the GUI's "Exclusions" box for each backup type.
 
-The list syntax is deliberately simple:
+The same syntax applies to all three lists (S3 buckets, DynamoDB tables, and GitHub repos):
 
 - `#` starts a comment that runs to the end of the line. This works for whole-line comments and for inline
   trailing comments, e.g. `my-bucket  # too big, backed up elsewhere`.

--- a/bup/gui/run_backup_widget.py
+++ b/bup/gui/run_backup_widget.py
@@ -107,6 +107,9 @@ class BackupWidget(QGroupBox):
                 # read exclusions into the DB
                 exclusions = ExclusionPreferences(self.backup_type.name)
                 self.display_boxes[display_type].text_box.setText("\n".join(exclusions.get()))
+                self.display_boxes[display_type].text_box.setToolTip(
+                    "One name per line. '#' starts a comment (whole line or trailing, e.g. 'my-bucket  # note'). Blank lines and surrounding whitespace are ignored."
+                )
                 self.display_boxes[display_type].text_box.textChanged.connect(self.exclusions_save_timer.start)
             else:
                 self.display_boxes[display_type].text_box.setReadOnly(True)

--- a/bup/preferences.py
+++ b/bup/preferences.py
@@ -74,9 +74,11 @@ class ExclusionPreferences(PrefOrderedSet):
 
     def get_no_comments(self) -> List[str]:
         """
-        Exclusion entries with rudimentary sanitization applied: comment lines (first non-whitespace character is "#")
-        and blank/whitespace-only lines are dropped, and leading/trailing whitespace is stripped from the remaining entries
-        so that e.g. "my-bucket " still matches "my-bucket".
+        Exclusion entries with rudimentary sanitization applied: anything from a "#" to the end of the line is a comment
+        (so both whole-line comments and inline trailing comments such as "my-bucket  # note" are supported), comments and
+        blank/whitespace-only lines are dropped, and leading/trailing whitespace is stripped from the remaining entries
+        so that e.g. "my-bucket " still matches "my-bucket". "#" can not appear in S3 bucket, DynamoDB table, or GitHub
+        repo names, so there is no need for an escape.
         """
-        stripped_entries = [s.strip() for s in super().get()]
-        return [s for s in stripped_entries if len(s) > 0 and not s.startswith("#")]
+        entries_without_comments = [s.split("#", 1)[0].strip() for s in super().get()]
+        return [s for s in entries_without_comments if len(s) > 0]

--- a/test_bup/test_dynamodb_backup.py
+++ b/test_bup/test_dynamodb_backup.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from botocore.exceptions import ClientError, NoCredentialsError
 
-from bup import UITypes
+from bup import UITypes, BackupTypes, ExclusionPreferences
 from bup.dynamodb_backup import DynamoDBBackup
 
 
@@ -91,6 +91,36 @@ def test_excluded_table_is_skipped(mock_get_prefs, mock_ddb_access, mock_exclusi
     assert not (tmp_path / "dynamodb" / "excluded_table.pickle").exists()
     assert (tmp_path / "dynamodb" / "backed_up_table.pickle").exists()
     assert any("excluding excluded_table" in i for i in infos)
+
+
+@patch("bup.dynamodb_backup.dynamodb_to_json", return_value="{}")
+@patch("bup.dynamodb_backup.DynamoDBAccess")
+@patch("bup.dynamodb_backup.get_preferences")
+def test_exclusion_list_comments_apply_to_tables(mock_get_prefs, mock_ddb_access, mock_to_json, tmp_path):
+    """
+    Uses the real (not mocked) exclusion store to prove the exclusion list syntax - whole-line comments, inline
+    trailing comments, blank lines and surrounding whitespace - applies to DynamoDB tables.
+    """
+    mock_get_prefs.return_value = _make_preferences(tmp_path)
+    exclusions = ExclusionPreferences(BackupTypes.DynamoDB.name)
+    saved_exclusions = exclusions.get()
+    try:
+        exclusions.set(["# tables to skip", "  excluded_table  # too big", "", "#commented_out_table"])
+        table = MagicMock()
+        table.scan_table_cached.return_value = [{"id": 1}]
+        mock_ddb_access.side_effect = _make_dynamodb_access_factory(["excluded_table", "commented_out_table", "backed_up_table"], {"commented_out_table": table, "backed_up_table": table})
+        infos = []
+        backup = _make_backup(info=infos.append)
+
+        backup.run()
+    finally:
+        exclusions.set(saved_exclusions)
+
+    assert not (tmp_path / "dynamodb" / "excluded_table.pickle").exists()
+    assert (tmp_path / "dynamodb" / "commented_out_table.pickle").exists()  # a commented-out entry does not exclude
+    assert (tmp_path / "dynamodb" / "backed_up_table.pickle").exists()
+    assert any("excluding excluded_table" in i for i in infos)
+    assert any("1 excluded" in i for i in infos)  # comment-only lines don't count as exclusions
 
 
 @patch("bup.dynamodb_backup.dynamodb_to_json", return_value="{}")

--- a/test_bup/test_preferences.py
+++ b/test_bup/test_preferences.py
@@ -41,9 +41,13 @@ def test_exclusions_sanitization():
         "bucket-a",
         "  bucket-b  ",  # leading/trailing whitespace is stripped
         "bucket-c	",
+        "bucket-d  # an inline trailing comment",
+        "bucket-e#no space before the comment",
+        "  bucket-f # comment with # another hash",
+        "#bucket-g",  # entirely commented out, even without a space
     ]
     exclusions.set(test_list)
-    assert exclusions.get_no_comments() == ["bucket-a", "bucket-b", "bucket-c"]
+    assert exclusions.get_no_comments() == ["bucket-a", "bucket-b", "bucket-c", "bucket-d", "bucket-e", "bucket-f"]
 
     # restore
     exclusions.set(saved_exclusions)


### PR DESCRIPTION
## Summary
- `#` now starts a comment anywhere on a line, so `my-bucket  # note` excludes `my-bucket`. `#` can't appear in S3 bucket, DynamoDB table, or GitHub repo names, so no escape mechanism is needed.
- Blank-line dropping and whitespace stripping (PR #39) are unchanged.
- **Docs:** new "Exclusions" section in README describing the syntax with an example; tooltip on the GUI Exclusions box; CLAUDE.md note updated.
- **Tests:** inline comment with and without a space before `#`, a second `#` inside a comment, `#name` fully commented out.

## Test plan
- [x] `pytest test_bup` — 124 passed locally
- [x] flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eEW1r522zUKgHWkFNWRAf