### PR TITLE
GitHub backup: mirror branches with fetch + reset, not git pull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ python -m bup <path> -s    # CLI with S3 backup
 **Three backup implementations:**
 - `S3Backup` - Uses awsimple + AWS CLI subprocess for bucket syncing
 - `DynamoDBBackup` - Uses awsimple, exports tables to pickle and JSON
-- `GithubBackup` - Uses github3.py for API access, GitPython for git operations (clone/pull all branches)
+- `GithubBackup` - Uses github3.py for API access, GitPython for git operations (clone, then mirror every branch by `fetch --prune` + `reset --hard origin/<branch>` - never `git pull`, so force-pushed/orphan branches never trigger a re-clone)
 
 **Preferences:** SQLite-backed via the `pref` library with `attrs` data classes. CLI and GUI have separate preference stores. Exclusion lists (per backup type) are sanitized by `ExclusionPreferences.get_no_comments()`: `#` starts a comment (whole-line or inline trailing), blank lines are dropped, and entries are whitespace-stripped (see README "Exclusions").
 

--- a/bup/github_backup.py
+++ b/bup/github_backup.py
@@ -99,7 +99,7 @@ class GithubBackup(BupBase):
                     except GitCommandError as e:
                         self.warning_out(self.redact(f'could not pull "{repo_dir}" - will try to start over and do a clone of "{repo_owner_and_name},{e}","{__file__}"'))
 
-                # new to us (or the pull failed, e.g. a force-pushed branch with a rewritten history) - clone the repo
+                # new to us (or the fetch/reset failed, e.g. a corrupt local clone) - clone the repo
                 if not pull_success:
                     try:
                         if repo_dir.exists():
@@ -145,6 +145,20 @@ class GithubBackup(BupBase):
                 except (GitCommandError, AttributeError, ValueError) as e:
                     log.warning(self.redact(f'could not set remote url for "{repo_dir}" : {e}'))
 
+            # A backup is a mirror: the goal is "local == remote, exactly", never to integrate histories.
+            # So this is fetch + hard reset to the remote-tracking ref (the model git itself uses for mirrors),
+            # not "git pull" - a merge would fail on any force-pushed branch (rebased feature branches,
+            # CI-owned branches such as gh-pages or badges, orphan branches) and trigger a needless full re-clone.
+            # One fetch per repo transfers every branch's objects in a single negotiation; --prune drops
+            # remote-tracking refs for branches deleted on GitHub so the local ref set stays honest.
+            self.info_out(f'git fetch "{repo_name}"')
+            try:
+                git_repo.git.fetch("--prune", "origin")
+            except GitCommandError as e:
+                # recoverable - the caller falls back to a fresh clone, and escalates to an error if that also fails
+                self.warning_out(self.redact(f"{repo_name} : {e}"))
+                return False
+
             for branch in branches:
                 if self.stop_requested:
                     break
@@ -154,17 +168,18 @@ class GithubBackup(BupBase):
                 if branch_name.lower() == "main" or (main_branch is None and branch_name.lower() == "master"):
                     main_branch = branch
 
-                self.info_out(f'git pull "{repo_name}" branch:"{branch_name}"')
+                self.info_out(f'git reset "{repo_name}" branch:"{branch_name}"')
                 try:
                     git_repo.git.reset("--hard")
                     git_repo.git.clean("-fd")
-                    git_repo.git.checkout(branch_name)
-                    git_repo.git.pull()
+                    git_repo.git.checkout(branch_name)  # creates a local tracking branch from origin/<name> on first sight
+                    git_repo.git.reset("--hard", f"origin/{branch_name}")
+                    git_repo.git.clean("-fd")
                     success = True
                 except GitCommandError as e:
                     if "did not match any file".lower() in str(e).lower():
                         # new branch with no files yet - skip it and continue with other branches
-                        self.info_out(f"git pull {repo_name} branch:{branch_name} - no files")
+                        self.info_out(f"git reset {repo_name} branch:{branch_name} - no files")
                         continue
                     elif "would be overwritten by checkout" in str(e).lower():
                         # typically caused by CRLF line-ending normalization on Windows, not actual user edits
@@ -172,7 +187,7 @@ class GithubBackup(BupBase):
                         success = False
                         break
                     else:
-                        # recoverable (e.g. a force-pushed branch whose rewritten history can't be merged) -
+                        # recoverable (e.g. a corrupt object store) -
                         # the caller falls back to a fresh clone, and escalates to an error if that also fails
                         self.warning_out(self.redact(f"{repo_name} : {e}"))
                         success = False

--- a/test_bup/test_github_backup.py
+++ b/test_bup/test_github_backup.py
@@ -83,16 +83,15 @@ def test_reset_hard_called_before_switch(github_backup, tmp_path):
     assert reset_indices[-1] < switch_indices[0], "reset --hard must come before git switch"
 
 
-def test_other_git_errors_use_warning_out(github_backup, tmp_path):
+def test_fetch_failure_is_warning_not_error(github_backup, tmp_path):
     """
-    Unexpected git pull errors (e.g. 'refusing to merge unrelated histories' after a force-push)
-    are warnings, not errors - the caller falls back to a fresh clone and only escalates to an
-    error if that also fails.
+    A failed fetch (e.g. a corrupt local clone) is a warning, not an error - the caller falls back
+    to a fresh clone and only escalates to an error if that also fails.
     """
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
     mock_repo = MagicMock()
-    mock_repo.git.pull.side_effect = GitCommandError(["git", "pull"], 128, stderr=b"fatal: refusing to merge unrelated histories")
+    mock_repo.git.fetch.side_effect = GitCommandError(["git", "fetch"], 128, stderr=b"fatal: bad object HEAD")
 
     with patch("git.Repo", return_value=mock_repo):
         result = github_backup.pull_branches("owner/repo", [_branch("main")], repo_dir)
@@ -100,6 +99,33 @@ def test_other_git_errors_use_warning_out(github_backup, tmp_path):
     assert result is False
     assert len(github_backup._errors) == 0
     assert len(github_backup._warnings) == 1
+    mock_repo.git.checkout.assert_not_called()
+
+
+def test_mirror_is_fetch_once_then_reset_per_branch(github_backup, tmp_path):
+    """
+    A backup mirrors the remote: one `fetch --prune` per repo, then every branch is hard-reset to its
+    remote-tracking ref. `git pull` (a merge) must never be used - it fails on force-pushed or orphan
+    branches (rebased feature branches, CI-owned badges/gh-pages) and would force a full re-clone.
+    """
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    mock_repo = MagicMock()
+
+    with patch("git.Repo", return_value=mock_repo):
+        result = github_backup.pull_branches("owner/repo", [_branch("main"), _branch("badges")], repo_dir)
+
+    assert result is True
+    assert len(github_backup._warnings) == 0
+    git_calls = mock_repo.git.mock_calls
+    assert git_calls.count(call.fetch("--prune", "origin")) == 1
+    mock_repo.git.pull.assert_not_called()
+    for branch_name in ("main", "badges"):
+        checkout_index = git_calls.index(call.checkout(branch_name))
+        reset_index = git_calls.index(call.reset("--hard", f"origin/{branch_name}"))
+        assert checkout_index < reset_index, f"{branch_name}: checkout must precede reset to the remote-tracking ref"
+    fetch_index = git_calls.index(call.fetch("--prune", "origin"))
+    assert fetch_index < git_calls.index(call.checkout("main")), "fetch must precede every branch"
 
 
 def test_single_branch_no_switch(github_backup, tmp_path):


### PR DESCRIPTION
## Why

bup ran `git checkout <branch>` + `git pull` for every branch of every repo. A backup is a mirror — the goal is "local == remote, exactly" — so a merge-style pull was the wrong operation. Any force-pushed branch (rebased feature branches, CI-owned branches like `badges`/`gh-pages`, orphan branches) failed with `fatal: refusing to merge unrelated histories`, and bup "recovered" by deleting and **re-cloning the entire repository on every run**. `jamesabel/remotedesktop` hit this on every backup because its CI force-pushes a coverage badge to the orphan `badges` branch.

## What

- One `git fetch --prune origin` per repo (every branch's objects in a single negotiation; remote-tracking refs for branches deleted on GitHub are dropped), then per branch `checkout` + `reset --hard origin/<branch>` + `clean -fd`. This is the model git itself uses for mirrors.
- Fetch failure → warning + `False`, so the existing re-clone fallback still covers a genuinely broken local clone — it just stops being the normal path.
- Tests: replaced the `git.pull`-based test with a fetch-failure test and a test asserting fetch-once / reset-per-branch / no `pull`.
- CLAUDE.md architecture note updated.

## Verification

`pytest test_bup`: 126 passed. flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFLRQLohWjXsMKM3h36jyz
