### PR TITLE
Bump version to 0.14.0

### DIFF
--- a/bup/__version__.py
+++ b/bup/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.3"
+__version__ = "0.14.0"
 __application_name__ = "bup"
 __title__ = __application_name__
 __author__ = "abel"


### PR DESCRIPTION
Minor bump for #42: GitHub backups now mirror branches with `fetch --prune` + `reset --hard origin/<branch>` instead of `git pull`, so force-pushed/orphan branches no longer trigger a full re-clone on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFLRQLohWjXsMKM3h36jyz