### PR TITLE
Self-update through the gated feed on www.abel.co; bucket no longer public

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ bup = ["bup.png", "bup.ico", "LICENSE", "gpl-3.0.md"]
 [tool.pyship]
 ui = "gui"
 upload = true
-public_readable = true
+# The pyship-abel-bup bucket is private now; installed copies self-update through the
+# gated feed on www.abel.co (see pyship launcher update_url).
+public_readable = false
+update_url = "https://www.abel.co/updates/bup"
 
 # registry settings pyship is using has been flagging a false positve on Windows defender so don't use run_on_startup for now
 run_on_startup = false


### PR DESCRIPTION
`pyship-abel-bup` is private now. With pyship #50 (launcher self-update), `[tool.pyship] update_url` makes the launcher poll `https://www.abel.co/updates/bup` for newer CLIPs and stage them for the next launch. `public_readable` is off because nothing reads the bucket anonymously any more.

Note: this takes effect on the next release built with the new pyship; already-installed copies (built with the old launcher) need a one-time reinstall from https://www.abel.co/downloads/bup-installer-win64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XisoprDUbbYRcMKNuvLTfU